### PR TITLE
Only include file path relative to pwd in formatter

### DIFF
--- a/lib/standard/formatter.rb
+++ b/lib/standard/formatter.rb
@@ -5,9 +5,12 @@ module Standard
     def file_finished(file, offenses)
       uncorrected_offenses = offenses.reject(&:corrected?)
       print_header_once unless uncorrected_offenses.empty?
+      working_directory = Pathname.new(Dir.pwd)
 
       uncorrected_offenses.each do |o|
-        output.printf("  %s:%d:%d: %s\n", file, o.line, o.real_column, o.message.tr("\n", " "))
+        absolute_path = Pathname.new(file)
+        relative_path = absolute_path.relative_path_from(working_directory)
+        output.printf("  %s:%d:%d: %s\n", relative_path, o.line, o.real_column, o.message.tr("\n", " "))
       end
     end
 


### PR DESCRIPTION
Of course I'm assuming `Dir.pwd` will give us the correct working directory
path here which may not pan out in some cases if the executable is somehow
invoked from outside the root directory of the project we're scanning but
this dramatically improved output quality for me from:

```
$ bundle exec standard
standard: Use Ruby Standard Style (https://github.com/testdouble/standard)
standard: Run `standard --fix` to automatically fix some problems.
  /Users/olivierlacan/Library/Mobile Documents/com~apple~CloudDocs/Development/perso/etalon/etalon.gemspec:11:24: Style/PercentLiteralDelimiters: `%q`-literals should be delimited by `(` and `)`.
  /Users/olivierlacan/Library/Mobile Documents/com~apple~CloudDocs/Development/perso/etalon/etalon.gemspec:11:24: Style/UnneededPercentQ: Use `%q` only for strings that contain both single quotes and double quotes.
  /Users/olivierlacan/Library/Mobile Documents/com~apple~CloudDocs/Development/perso/etalon/etalon.gemspec:12:24: Style/PercentLiteralDelimiters: `%q`-literals should be delimited by `(` and `)`.
  /Users/olivierlacan/Library/Mobile Documents/com~apple~CloudDocs/Development/perso/etalon/etalon.gemspec:12:24: Style/UnneededPercentQ: Use `%q` only for strings that contain both single quotes and double quotes.
  /Users/olivierlacan/Library/Mobile Documents/com~apple~CloudDocs/Development/perso/etalon/etalon.gemspec:16:16: Layout/ExtraSpacing: Unnecessary spacing detected.
  /Users/olivierlacan/Library/Mobile Documents/com~apple~CloudDocs/Development/perso/etalon/etalon.gemspec:16:22: Layout/SpaceAroundOperators: Operator `=` should be surrounded by a single space.
  /Users/olivierlacan/Library/Mobile Documents/com~apple~CloudDocs/Development/perso/etalon/etalon.gemspec:26:13: Layout/ExtraSpacing: Unnecessary spacing detected.
```

To:

```
$ bundle exec standard
standard: Use Ruby Standard Style (https://github.com/testdouble/standard)
standard: Run `standard --fix` to automatically fix some problems.
  etalon.gemspec:11:24: Style/PercentLiteralDelimiters: `%q`-literals should be delimited by `(` and `)`.
  etalon.gemspec:11:24: Style/UnneededPercentQ: Use `%q` only for strings that contain both single quotes and double quotes.
  etalon.gemspec:12:24: Style/PercentLiteralDelimiters: `%q`-literals should be delimited by `(` and `)`.
  etalon.gemspec:12:24: Style/UnneededPercentQ: Use `%q` only for strings that contain both single quotes and double quotes.
  etalon.gemspec:16:16: Layout/ExtraSpacing: Unnecessary spacing detected.
  etalon.gemspec:16:22: Layout/SpaceAroundOperators: Operator `=` should be surrounded by a single space.
  etalon.gemspec:26:13: Layout/ExtraSpacing: Unnecessary spacing detected.
```

Fixes #5