### PR TITLE
Get an MRI 1.8 project passing under standard

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -1,3 +1,7 @@
+AllCops:
+  # Prevent RuboCop from exploding when it finds an older-than-2.2 .ruby-version
+  TargetRubyVersion: 2.5
+
 Bundler/OrderedGems:
   Enabled: false
 

--- a/config/ruby-1.8.yml
+++ b/config/ruby-1.8.yml
@@ -1,0 +1,4 @@
+inherit_from: ./ruby-1.9.yml
+
+Style/Lambda:
+  Enabled: false

--- a/config/ruby-1.9.yml
+++ b/config/ruby-1.9.yml
@@ -1,0 +1,4 @@
+inherit_from: ./ruby-2.2.yml
+
+Style/Encoding:
+  Enabled: false

--- a/config/ruby-2.2.yml
+++ b/config/ruby-2.2.yml
@@ -1,0 +1,8 @@
+inherit_from: ./base.yml
+
+AllCops:
+  TargetRubyVersion: 2.2
+
+Layout:
+  IndentHeredoc:
+    Enabled: false

--- a/lib/standard/config.rb
+++ b/lib/standard/config.rb
@@ -55,7 +55,7 @@ module Standard
     end
 
     def mutate_config_store!(config_store)
-      config_store.options_config = Pathname.new(__dir__).join("../../config/base.yml")
+      config_store.options_config = rubocop_yaml_path(@standard_config[:ruby_version])
       options_config = config_store.instance_variable_get("@options_config")
 
       options_config["AllCops"]["TargetRubyVersion"] = floatify_version(
@@ -69,6 +69,20 @@ module Standard
           options_config[cop]["Exclude"] |= [Pathname.new(@standard_yml_path).dirname.join(path).to_s]
         end
       end
+    end
+
+    def rubocop_yaml_path(desired_version)
+      file_name = if desired_version < Gem::Version.new("1.9")
+        "ruby-1.8.yml"
+      elsif desired_version < Gem::Version.new("2.0")
+        "ruby-1.9.yml"
+      elsif desired_version < Gem::Version.new("2.3")
+        "ruby-2.2.yml"
+      else
+        "base.yml"
+      end
+
+      Pathname.new(__dir__).join("../../config/#{file_name}")
     end
 
     def expand_ignore_config(ignore_config)


### PR DESCRIPTION
- This "tricks" RuboCop into loading files for older rubies by setting
TargetRubyVersion, even though we override it when invoking the runner
- Note that each Ruby unsupported by RuboCop will need to have its own
yaml file so we can specify rules to disable that are specific to older
rubies