### PR TITLE
Allow Standard to integrate with AtomLinter

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,20 @@ $ rake standard STANDARDOPTS="--format progress"
 $ rake standard STANDARDOPTS="lib \"app/**/*\""
 ```
 
+## Using with AtomLinter
+
+Standard is compatible with [AtomLinter](https://atomlinter.github.io/)'s
+[linter-rubocop](https://github.com/AtomLinter/linter-rubocop) package. To use
+Standard with linter-rubocop, you need to do two things:
+
+1. Configure linter-rubocop to run `standard` as its **Command**.
+2. Add the flags `--silence-cta --no-display-cop-names` to the end of the
+   **Command**. The first flag will suppress Standard's pre-1.0 CTA message when
+   warnings are detected. The second will prevent RuboCop from showing cop names
+   in offense messages.
+
+Now you can see Standard's warnings in Atom.
+
 ## What you might do if you're clever
 
 If you want or need to configure Standard, there are a _handful_ of options

--- a/lib/standard/cli.rb
+++ b/lib/standard/cli.rb
@@ -11,7 +11,13 @@ module Standard
     end
 
     def run
-      rubocop_config = @config.call(@argv)
+      rubocop_config, standard_config = @config.call(@argv)
+
+      if standard_config.options[:version]
+        puts Standard::VERSION
+        return SUCCESS_STATUS_CODE
+      end
+
       runner = RuboCop::Runner.new(
         rubocop_config.options,
         rubocop_config.config_store
@@ -25,11 +31,13 @@ module Standard
         (runner.warnings + runner.errors).each do |message|
           warn message
         end
-        puts <<-CALL_TO_ACTION.gsub(/^ {10}/, "")
+        unless standard_config.options[:silence_cta]
+          puts <<-CALL_TO_ACTION.gsub(/^ {10}/, "")
 
-          Notice: Disagree with these rules? While StandardRB is pre-1.0.0, feel free to submit suggestions to:
-            https://github.com/testdouble/standard/issues/new
-        CALL_TO_ACTION
+            Notice: Disagree with these rules? While StandardRB is pre-1.0.0, feel free to submit suggestions to:
+              https://github.com/testdouble/standard/issues/new
+          CALL_TO_ACTION
+        end
         FAILURE_STATUS_CODE
       end
     end

--- a/lib/standard/config.rb
+++ b/lib/standard/config.rb
@@ -15,11 +15,12 @@ module Standard
     def call(argv, search_path = Dir.pwd)
       standard_config = @loads_yaml_config.call(search_path)
       settings = @merges_settings.call(argv, standard_config)
-      RuboCopConfig.new(
+      rubocop_config = RuboCopConfig.new(
         settings.paths,
         settings.options,
         @creates_config_store.call(standard_config)
       )
+      [rubocop_config, settings]
     end
   end
 end

--- a/lib/standard/merges_settings.rb
+++ b/lib/standard/merges_settings.rb
@@ -18,16 +18,19 @@ module Standard
     private
 
     def separate_argv(argv)
-      argv.partition { |flag|
-        flag == "--fix"
-      }
+      argv.partition { |flag| %w[--fix --silence-cta --version -v].include?(flag) }
     end
 
     def parse_standard_argv(argv)
       argv.each_with_object({}) { |arg, cli_flags|
-        if arg == "--fix"
+        case arg
+        when "--version", "-v"
+          cli_flags[:version] = true
+        when "--fix"
           cli_flags[:auto_correct] = true
           cli_flags[:safe_auto_correct] = true
+        when "--silence-cta"
+          cli_flags[:silence_cta] = true
         end
       }
     end


### PR DESCRIPTION
👋👋

I was really excited to see Standard come out! After reading the Readme, I thought it would be easy to use Standard with any RuboCop-compatible tools because, like the Readme says, Standard is just a wrapper around RuboCop. It didn't work at first, but I only had to make a few small changes to the gem to get it working. Hopefully these are changes that would be okay to include in the gem itself!

- The CLI now supports `-v` and `--version` to print out the RuboCop version that Standard is using under the hood. This is because AtomLinter requests to know the RuboCop version in order to alter the CLI flags it passes when linting.

  I'm not sure how this would relate to #16, or if that issue is talking about something else.
- The config file now supports `silence_cta`. Setting this to `true` will silence the CTA message that is printed after the warning output. This is because AtomLinter wants to consume the RuboCop offenses as JSON, but having the CTA message printed at the end makes the contents of stdout invalid JSON. The default of this option is `false` so it should not impact the default behavior of the tool.

  I also thought about making this a CLI flag, but I wasn't sure which one would be a better idea.

I believe these changes should enable Standard to work with other linter tools that are compatible with RuboCop besides AtomLinter. However, I am not a user of any other tools, so I can't vouch for compatibility one way or the other.