### PR TITLE
Fixes README.md styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ No decisions to make. It just works. Here's a [⚡ lightning talk ⚡](https://w
 Install by adding it to your Gemfile:
 
 ```ruby
-gem "standard", :group => [:development, :test]
+gem "standard", group: [:development, :test]
 ```
 
 And running `bundle install`.


### PR DESCRIPTION
I mean... you had to see this coming... right?

Maybe not, I mean, I doubt the linter works on the `.md` files by default anyway, right...


```
/me checks the source of `standard` just to be sure... hold plz...
```

...

(oh... it just uses `rubocop` under the hood... well that is good)

...


```
/me checks the source of `rubocop`... hold plz...
```

...


Okay, yeah, you don't... and probably checking code blocks for this stuff would be a PITA anyway... #scopeCreep