### PR TITLE
Disable Style/RaiseArgs

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -967,9 +967,6 @@ Style/PreferredHashMethods:
 Style/Proc:
   Enabled: true
 
-Style/RaiseArgs:
-  Enabled: true
-
 Style/RandomWithOffset:
   Enabled: true
 


### PR DESCRIPTION
The recommended style `raise RuntimeError, "message"` generally looks better than `raise RuntimeError.new("message")` because it is a variant of `raise "message"` with an explicit exception class supplied.  However, when the argument is not a message string, the comma style does not read well because the second argument is not what `raise` would take but is just an argument for the first argument's constructor that's passed through.

e.g.
```ruby
raise ActiveRecord::RecordInvalid, record
```

So, I'm not in favor of forcing this style unless this cop learns to do the conversion only if the second argument is a string literal.

What do you think?