### PR TITLE
Prefer each.with_index and each.with_object

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -782,6 +782,19 @@ Style/ClassMethods:
 Style/ClassVars:
   Enabled: true
 
+# Enable to specify a preference for each_with_* methods.
+# Use ~ (nil) to ignore the default preference for all other methods.
+Style/CollectionMethods:
+  Enabled: true
+  PreferredMethods:
+    collect: ~
+    collect!: ~
+    inject: ~
+    detect: ~
+    find_all: ~
+    each_with_index: 'each.with_index'
+    each_with_object: 'each.with_object'
+
 Style/ColonMethodCall:
   Enabled: true
 

--- a/config/ruby-1.8.yml
+++ b/config/ruby-1.8.yml
@@ -1,8 +1,10 @@
 inherit_from: ./ruby-1.9.yml
 
+Style/CollectionMethods:
+  Enabled: false
+
 Style/Lambda:
   Enabled: false
 
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
-


### PR DESCRIPTION
I have [long held belief](https://collectiveidea.com/blog/archives/2014/11/27/lets-simplify-ruby) that we should encourage `each.with_index` over `each_with_index`. It comes from years of teaching Ruby. Someone would inevitably ask if there was a `map_with_index` (there isn't). I realized it was better to introduce `each.with_index` instead, so that they naturally would think to try `map.with_index` and find out that it Just Works™.

Rubocop [nicely converts](https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/cop/style/each_with_object.rb) `inject` to `each_with_object` where it can, and this goes a step farther by converting it to `each.with_object`.

Before:
```ruby
list.each_with_index do |item, index|
  puts item[index]
end

list.each_with_object do |item, result|
  result[item] = "something"
end

list.inject({}) do |result, item|
  result[item] = "something"
  result
end
```

After this patch, running `--fix` produces: 

```ruby
list.each.with_index do |item, index|
  puts item[index]
end

list.each.with_object do |item, result|
  result[item] = "something"
end

list.each.with_object({}) do |item, result|
  result[item] = "something"
end
```

This is a possibly unpopular hill that I'm willing to shed blood defending.