### PR TITLE
Disable Style/PerlBackrefs

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -958,9 +958,6 @@ Style/PercentLiteralDelimiters:
 Style/PercentQLiterals:
   Enabled: true
 
-Style/PerlBackrefs:
-  Enabled: true
-
 Style/PreferredHashMethods:
   Enabled: true
 


### PR DESCRIPTION
It is painful to see every occurrence of `$n` expanded to `Regexp.last_match(n)` only to get more lengthy and slower code.

For instance, the following piece of code:
```ruby
str.gsub!(/([a-z]+)_([a-z]+)/) { $1.capitalize + $2.capitalize }
```
gets corrected to this:
```ruby
str.gsub!(/([a-z]+)_([a-z]+)/) { Regexp.last_match(1).capitalize + Regexp.last_match(2).capitalize }
```
and it no longer fits nicely in one line on the screen.

I, as one coming from the Unix background, don't feel like `$1`-`$9` are so [cryptic](https://github.com/rubocop-hq/ruby-style-guide#no-perl-regexp-last-matchers) you should avoid them, but is that true for the folks out there?