### PR TITLE
Add --no-fix option

### DIFF
--- a/lib/standard/merges_settings.rb
+++ b/lib/standard/merges_settings.rb
@@ -20,7 +20,7 @@ module Standard
 
     def separate_argv(argv)
       argv.partition { |flag|
-        ["--fix", "--version", "-v", "--help", "-h"].include?(flag)
+        ["--fix", "--no-fix", "--version", "-v", "--help", "-h"].include?(flag)
       }
     end
 
@@ -29,6 +29,9 @@ module Standard
         if arg == "--fix"
           cli_flags[:auto_correct] = true
           cli_flags[:safe_auto_correct] = true
+        elsif arg == "--no-fix"
+          cli_flags[:auto_correct] = false
+          cli_flags[:safe_auto_correct] = false
         end
       }
     end

--- a/lib/standard/runners/help.rb
+++ b/lib/standard/runners/help.rb
@@ -9,7 +9,7 @@ module Standard
 
           Options:
 
-            --fix             Automatically fix failures where possible
+            --[no-]fix        Automatically fix failures where possible
             --format <name>   Format output with any RuboCop formatter (e.g. "json")
             -v, --version     Print the version of Standard
             -h, --help        Print this message

--- a/lib/standard/runners/help.rb
+++ b/lib/standard/runners/help.rb
@@ -9,7 +9,8 @@ module Standard
 
           Options:
 
-            --[no-]fix        Automatically fix failures where possible
+            --fix             Automatically fix failures where possible
+            --no-fix          Do not automatically fix failures
             --format <name>   Format output with any RuboCop formatter (e.g. "json")
             -v, --version     Print the version of Standard
             -h, --help        Print this message

--- a/test/standard/merges_settings_test.rb
+++ b/test/standard/merges_settings_test.rb
@@ -38,4 +38,14 @@ class Standard::MergesSettingsTest < UnitTest
     assert_equal options[:auto_correct], false
     assert_equal options[:safe_auto_correct], false
   end
+
+  def test_last_fix_flag_wins
+    fix_options = @subject.call(["--no-fix", "--fix"], {}).options
+    no_fix_options = @subject.call(["--fix", "--no-fix"], {}).options
+
+    assert_equal fix_options[:auto_correct], true
+    assert_equal fix_options[:safe_auto_correct], true
+    assert_equal no_fix_options[:auto_correct], false
+    assert_equal no_fix_options[:safe_auto_correct], false
+  end
 end

--- a/test/standard/merges_settings_test.rb
+++ b/test/standard/merges_settings_test.rb
@@ -24,4 +24,18 @@ class Standard::MergesSettingsTest < UnitTest
     assert_equal :version, @subject.call(["--version"], {}).runner
     assert_equal :version, @subject.call(["-v"], {}).runner
   end
+
+  def test_fix_flag_sets_auto_correct_options
+    options = @subject.call(["--fix"], {}).options
+
+    assert_equal options[:auto_correct], true
+    assert_equal options[:safe_auto_correct], true
+  end
+
+  def test_no_fix_flag_inverts_auto_correct_options
+    options = @subject.call(["--no-fix"], {}).options
+
+    assert_equal options[:auto_correct], false
+    assert_equal options[:safe_auto_correct], false
+  end
 end

--- a/test/standard/runners/help_test.rb
+++ b/test/standard/runners/help_test.rb
@@ -17,7 +17,8 @@ class Standard::Runners::HelpTest < UnitTest
 
       Options:
 
-        --[no-]fix        Automatically fix failures where possible
+        --fix             Automatically fix failures where possible
+        --no-fix          Do not automatically fix failures
         --format <name>   Format output with any RuboCop formatter (e.g. "json")
         -v, --version     Print the version of Standard
         -h, --help        Print this message

--- a/test/standard/runners/help_test.rb
+++ b/test/standard/runners/help_test.rb
@@ -17,7 +17,7 @@ class Standard::Runners::HelpTest < UnitTest
 
       Options:
 
-        --fix             Automatically fix failures where possible
+        --[no-]fix        Automatically fix failures where possible
         --format <name>   Format output with any RuboCop formatter (e.g. "json")
         -v, --version     Print the version of Standard
         -h, --help        Print this message


### PR DESCRIPTION
In the case that you use the config to automatically fix your violations `fix: true`, this flag will override that setting in the negative direction, just as --fix overrides the lack of that setting.

I went with `no-` as the prefix because it seems to be used most commonly for inverting options.

fixes #54