### PR TITLE
Fix a nil error in Formatter when no files were examined

### DIFF
--- a/lib/standard/formatter.rb
+++ b/lib/standard/formatter.rb
@@ -10,11 +10,11 @@ module Standard
     def initialize(*args)
       super
       @header_printed_already = false
+      @all_uncorrected_offenses = []
     end
 
     def file_finished(file, offenses)
       uncorrected_offenses = offenses.reject(&:corrected?)
-      @all_uncorrected_offenses ||= []
       @all_uncorrected_offenses += uncorrected_offenses
       print_header_once unless uncorrected_offenses.empty?
       working_directory = Pathname.new(Dir.pwd)

--- a/test/standard/formatter_test.rb
+++ b/test/standard/formatter_test.rb
@@ -85,6 +85,12 @@ class Standard::FormatterTest < UnitTest
     MESSAGE
   end
 
+  def test_no_offenses_without_files
+    @subject.finished([@some_path])
+
+    assert_empty @io.string
+  end
+
   private
 
   def call_to_action_message


### PR DESCRIPTION
The `@all_uncorrected_offenses` variable was only initialized in the
`file_finished` method. But if no files were analyzed, it never got
initialized, and in `finished`, it was still nil, and nil doesn't
respond to `.empty?`.

This change moves the initialization into the Formatter's initialize
method, so it's always present.