### PR TITLE
Upgrade rubocop to 0.63 to silence warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     standard (0.0.24)
-      rubocop (>= 0.60)
+      rubocop (>= 0.63)
 
 GEM
   remote: https://rubygems.org/
@@ -11,12 +11,12 @@ GEM
     coderay (1.1.2)
     docile (1.3.1)
     gimme (0.5.0)
-    jaro_winkler (1.5.1)
+    jaro_winkler (1.5.2)
     json (2.1.0)
     method_source (0.9.2)
     minitest (5.11.3)
-    parallel (1.12.1)
-    parser (2.5.3.0)
+    parallel (1.13.0)
+    parser (2.6.0.0)
       ast (~> 2.4.0)
     powerpack (0.1.2)
     pry (0.12.2)
@@ -24,7 +24,7 @@ GEM
       method_source (~> 0.9.0)
     rainbow (3.0.0)
     rake (12.3.2)
-    rubocop (0.62.0)
+    rubocop (0.63.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)

--- a/config/base.yml
+++ b/config/base.yml
@@ -315,6 +315,9 @@ Lint/EnsureReturn:
 Lint/ErbNewArguments:
   Enabled: true
 
+Lint/FlipFlop:
+  Enabled: true
+
 Lint/FloatOutOfRange:
   Enabled: true
 
@@ -830,9 +833,6 @@ Style/EndBlock:
   Enabled: true
 
 Style/EvalWithLocation:
-  Enabled: true
-
-Style/FlipFlop:
   Enabled: true
 
 Style/For:

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", ">= 0.60"
+  spec.add_dependency "rubocop", ">= 0.63"
 
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
Rubocop 0.63.0 [moved Style/FlipFlop to Lint/FlipFlop](https://github.com/rubocop-hq/rubocop/pull/6636) which generates a warning: `…config/base.yml: Style/FlipFlop has the wrong namespace - should be Lint` when standard is run.

This updates the base config and locks rubocop to >= 0.63.