### PR TITLE
Only show run command with fix message if command was run without it

### DIFF
--- a/lib/standard/formatter.rb
+++ b/lib/standard/formatter.rb
@@ -42,14 +42,24 @@ module Standard
 
       output.print <<-HEADER.gsub(/^ {8}/, "")
         standard: Use Ruby Standard Style (https://github.com/testdouble/standard)
-        standard: Run `#{command}` to automatically fix some problems.
       HEADER
+
+      unless auto_correct_option_provided?
+        output.print <<-HEADER.gsub(/^ {10}/, "")
+          standard: Run `#{command}` to automatically fix some problems.
+        HEADER
+      end
+
       @header_printed_already = true
     end
 
     def print_call_for_feedback
       output.print "\n"
       output.print CALL_TO_ACTION_MESSAGE
+    end
+
+    def auto_correct_option_provided?
+      options[:auto_correct] || options[:safe_auto_correct]
     end
   end
 end

--- a/test/standard/cli_test.rb
+++ b/test/standard/cli_test.rb
@@ -23,7 +23,6 @@ class Standard::CliTest < UnitTest
     assert_empty fake_err.string
     assert_equal <<-OUTPUT.gsub(/^ {6}/, ""), fake_out.string
       standard: Use Ruby Standard Style (https://github.com/testdouble/standard)
-      standard: Run `standardrb --fix` to automatically fix some problems.
         test/fixture/cli/unfixable-bad.rb:3:12: Lint/AssignmentInCondition: Wrap assignment in parentheses if intentional
 
       #{call_to_action_message}

--- a/test/standard/formatter_test.rb
+++ b/test/standard/formatter_test.rb
@@ -24,6 +24,19 @@ class Standard::FormatterTest < UnitTest
     assert_empty @io.string
   end
 
+  def test_does_not_print_fix_command_if_run_with_fix
+    @subject = Standard::Formatter.new(@io, auto_correct: true, safe_auto_correct: true)
+    @subject.file_finished(@some_path, [Offense.new(false, 42, 13, "Neat")])
+    @subject.finished([@some_path])
+
+    assert_equal <<-MESSAGE.gsub(/^ {6}/, ""), @io.string
+      standard: Use Ruby Standard Style (https://github.com/testdouble/standard)
+        Gemfile:42:13: Neat
+
+      #{call_to_action_message}
+    MESSAGE
+  end
+
   def test_prints_uncorrected_offenses
     @subject.file_finished(@some_path, [Offense.new(false, 42, 13, "Neat")])
     @subject.finished([@some_path])


### PR DESCRIPTION
Fixes #60 

I believe this handles the first task on the issue. I'm not sure if there is something extra I need to check for handling the second task - `Stop printing it when ... none of the detected problems were (safely) autofixable`