### PR TITLE
Only print suggestion to run --fix if there are actually fixable cop violations

### DIFF
--- a/lib/standard/helpers/autocorrectable.rb
+++ b/lib/standard/helpers/autocorrectable.rb
@@ -2,7 +2,8 @@ module Standard
   module Helpers
     module Autocorrectable
       def autocorrectable_offense?(offense)
-        cop_instance(offense.cop_name).support_autocorrect?
+        cop = cop_instance(offense.cop_name)
+        cop.support_autocorrect? && safely_autocorrectable?(cop)
       end
 
       def cop_instance(cop_name)
@@ -12,6 +13,11 @@ module Standard
       def constantized_cop(cop_name)
         namespaced_cop_class = cop_name.to_s.gsub("/", "::")
         RuboCop::Cop.const_get(namespaced_cop_class)
+      end
+
+      def safely_autocorrectable?(cop)
+        return true unless cop.cop_config
+        cop.cop_config.fetch("SafeAutoCorrect", true)
       end
     end
   end

--- a/lib/standard/helpers/autocorrectable.rb
+++ b/lib/standard/helpers/autocorrectable.rb
@@ -1,0 +1,18 @@
+module Standard
+  module Helpers
+    module Autocorrectable
+      def autocorrectable_offense?(offense)
+        cop_instance(offense.cop_name).support_autocorrect?
+      end
+
+      def cop_instance(cop_name)
+        constantized_cop(cop_name).new
+      end
+
+      def constantized_cop(cop_name)
+        namespaced_cop_class = cop_name.to_s.gsub("/", "::")
+        RuboCop::Cop.const_get(namespaced_cop_class)
+      end
+    end
+  end
+end

--- a/test/standard/helpers/autocorrectable_test.rb
+++ b/test/standard/helpers/autocorrectable_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+require "standard/helpers/autocorrectable"
+
+class Standard::Helpers::AutocorrectableTest < UnitTest
+  class MockClass
+    include Standard::Helpers::Autocorrectable
+  end
+
+  Offense = Struct.new(:cop_name)
+
+  def setup
+    @subject = MockClass.new
+  end
+
+  def test_returns_false_when_offense_is_not_autocorrectable
+    result = @subject.autocorrectable_offense?(Offense.new("Lint/UselessAssignment"))
+
+    assert_equal(false, result)
+  end
+
+  def test_returns_true_when_offense_is_autocorrectable
+    result = @subject.autocorrectable_offense?(Offense.new("Bundler/InsecureProtocolSource"))
+
+    assert_equal(true, result)
+  end
+end

--- a/test/standardrb_test.rb
+++ b/test/standardrb_test.rb
@@ -8,7 +8,6 @@ class StandardrbTest < UnitTest
     refute status.success?
     assert_same_lines <<-MSG.gsub(/^ {6}/, ""), stdout
       standard: Use Ruby Standard Style (https://github.com/testdouble/standard)
-      standard: Run `standardrb --fix` to automatically fix some problems.
         lib/foo/do_lint.rb:1:1: Lint/UselessAssignment: Useless assignment to variable - `useless_assignment`.
         lib/foo/tmp/do_lint.rb:1:1: Lint/UselessAssignment: Useless assignment to variable - `useless_assignment`.
         lib/do_lint.rb:1:1: Lint/UselessAssignment: Useless assignment to variable - `useless_assignment`.
@@ -30,7 +29,6 @@ class StandardrbTest < UnitTest
     refute status.success?
     assert_same_lines <<-MSG.gsub(/^ {6}/, ""), stdout
       standard: Use Ruby Standard Style (https://github.com/testdouble/standard)
-      standard: Run `standardrb --fix` to automatically fix some problems.
         do_lint.rb:1:1: Lint/UselessAssignment: Useless assignment to variable - `useless_assignment`.
         tmp/do_lint.rb:1:1: Lint/UselessAssignment: Useless assignment to variable - `useless_assignment`.
 


### PR DESCRIPTION
Fixes #60

## Decisions
From what I understood, there were two possible ways to tackle this problem:
1. Ask *something* whether each raised offense is autocorrectable or not;
2. Automatically run `--fix` in a clone of the verified file and check that no offense was raised.

I chose option **1.** because it seemed the simpler one.

## Result
After some (non-trivial) time digging into the Rubocop codebase, I found out that the `Offense` class has a [`attr_reader :cop_name`](https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/cop/offense.rb#L52), which returns the `Cop` subclass that raised said `Offense`. This `Cop` class also detains the information of [whether the related offense is autocorrectable or not](https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/cop/autocorrect_logic.rb#L15).

After finding that out, all that was left to do was to somehow leverage that information inside `Standard::Formatter`.

I'm not sure if my current solution diverges from some community or project Best Practice ™, but I would really appreciate some feedback before I invest more time into its refactoring.

Additional comments/reasoning can be found in the commit messages and diffs comments.


