### PR TITLE
Passing a hash to a setter gets treated like data, not keyword args

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -24,7 +24,7 @@ Layout/AlignArray:
 
 Layout/AlignHash:
   Enabled: true
-  EnforcedLastArgumentHashStyle: always_ignore
+  EnforcedLastArgumentHashStyle: ignore_implicit
 
 Layout/AlignParameters:
   Enabled: true


### PR DESCRIPTION
Without this patch, hash literals passed to setters are treated like keyword args (ie the middle one should be treated like the top one, but it's instead treated like the bottom one:

![image](https://user-images.githubusercontent.com/77495/52506855-7f84df00-2bb5-11e9-8208-0d97c4477770.png)

With this patch, it gets treated like the top one:

![image](https://user-images.githubusercontent.com/77495/52506895-9a575380-2bb5-11e9-8713-d3a94f36b0ba.png)

---

* Note that I am not condoning the setting, I'm only fixing the inconsistency.
* Note that this implicitly implies that keyword options should not have an explicit hash wrapped around them (or they'll be seen as data, not an argument structure).
* For more context, see @danielmorrison's example [here](https://github.com/testdouble/standard/issues/35#issuecomment-461821683)
