### PR TITLE
Instructions for Atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ feedback loop. Some editors support asynchronously running linters.
 
 1. Install [linter-rubocop](https://github.com/AtomLinter/linter-rubocop) package.
 
-2. Configure `linter-rubocop` to use either `standardrb` binstub (`./bin/standardrb`) or a globally installed `standardrb` (with absolute path).
+2. Configure `linter-rubocop` to use either `standardrb` [binstub](https://bundler.io/man/bundle-binstubs.1.html) (`./bin/standardrb`) or a globally installed `standardrb` (with absolute path).
 
 ![alt "linter-rubocop configuration"](https://user-images.githubusercontent.com/631534/54869518-e5aa7780-4d99-11e9-81e7-777654a4f91b.png)
 

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ $ bundle binstubs standard
 
 3. Configure `linter-rubocop` to use `./bin/standardrb` command.
 
-![alt "linter-rubocop configuration"](https://user-images.githubusercontent.com/631534/54869518-e5aa7780-4d99-11e9-81e7-777654a4f91b.png =400x)
+![alt "linter-rubocop configuration"](https://user-images.githubusercontent.com/631534/54869518-e5aa7780-4d99-11e9-81e7-777654a4f91b.png)
 
 ### Vim
 

--- a/README.md
+++ b/README.md
@@ -338,13 +338,8 @@ feedback loop. Some editors support asynchronously running linters.
 ### Atom
 
 1. Install [linter-rubocop](https://github.com/AtomLinter/linter-rubocop) package.
-2. Make sure you have `standardrb` binstubs generated.
 
-```bash
-$ bundle binstubs standard
-```
-
-3. Configure `linter-rubocop` to use `./bin/standardrb` command.
+2. Configure `linter-rubocop` to use either `standardrb` binstub (`./bin/standardrb`) or a globally installed `standardrb` (with absolute path).
 
 ![alt "linter-rubocop configuration"](https://user-images.githubusercontent.com/631534/54869518-e5aa7780-4d99-11e9-81e7-777654a4f91b.png)
 

--- a/README.md
+++ b/README.md
@@ -335,6 +335,19 @@ information.
 It can be very handy to know about failures while editing to shorten the
 feedback loop. Some editors support asynchronously running linters.
 
+### Atom
+
+1. Install [linter-rubocop](https://github.com/AtomLinter/linter-rubocop) package.
+2. Make sure you have `standardrb` binstubs generated.
+
+```bash
+bundle binstubs standard
+```
+
+3. Configure `linter-rubocop` to use `./bin/standardrb` command.
+
+![alt "linter-rubocop configuration"](https://user-images.githubusercontent.com/631534/54869518-e5aa7780-4d99-11e9-81e7-777654a4f91b.png)
+
 ### Vim
 
 Install [ale](https://github.com/w0rp/ale). And add these lines to your `.vimrc`

--- a/README.md
+++ b/README.md
@@ -341,12 +341,12 @@ feedback loop. Some editors support asynchronously running linters.
 2. Make sure you have `standardrb` binstubs generated.
 
 ```bash
-bundle binstubs standard
+$ bundle binstubs standard
 ```
 
 3. Configure `linter-rubocop` to use `./bin/standardrb` command.
 
-![alt "linter-rubocop configuration"](https://user-images.githubusercontent.com/631534/54869518-e5aa7780-4d99-11e9-81e7-777654a4f91b.png)
+![alt "linter-rubocop configuration"](https://user-images.githubusercontent.com/631534/54869518-e5aa7780-4d99-11e9-81e7-777654a4f91b.png =400x)
 
 ### Vim
 


### PR DESCRIPTION
Looks like [linter-rubocop](https://github.com/AtomLinter/linter-rubocop) can work directly with  `standardrb`. Adding instructions to README explaining how to set it all up. Does this solve #45?