### PR TITLE
Restrict rubocop version to <= 0.66

### DIFF
--- a/standard.gemspec
+++ b/standard.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", ">= 0.63"
+  spec.add_dependency "rubocop", ">= 0.63", "<= 0.66"
 
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
In [a recent commit][1], rubocop moved multiple performance cops to the style
section. This prevents the standardrb executable from running
successfully, showing the following errors:

```
Performance/RedundantSortBy has the wrong namespace - should be Style
Performance/Sample has the wrong namespace - should be Style
Performance/UnneededSort has the wrong namespace - should be Style
```

The commit went live in rubocop version 0.67. Restrict the rubocop
version to <= 0.66.

Closes #104 

[1]: https://github.com/rubocop-hq/rubocop/commit/32ed7d197855b66e16f1ef1a7ecdc409112ead14