### PR TITLE
undef before override, fixes #107

### DIFF
--- a/lib/standard/rubocop/ext.rb
+++ b/lib/standard/rubocop/ext.rb
@@ -1,5 +1,6 @@
 module RuboCop
   class Cop::Lint::AssignmentInCondition
+    undef_method :message
     def message(_)
       "Wrap assignment in parentheses if intentional"
     end


### PR DESCRIPTION
By undefining the method before redefining it, we avoid a runtime warning from Ruby which can pollute downstream test suites which run with warnings enabled.