### PR TITLE
Remove the while until modifier rule.

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -1023,8 +1023,5 @@ Style/WhenThen:
 Style/WhileUntilDo:
   Enabled: true
 
-Style/WhileUntilModifier:
-  Enabled: true
-
 Style/YodaCondition:
   Enabled: true


### PR DESCRIPTION
This would force users to replace:

```ruby
while a == b
  a
end
```

with

```ruby
a while a == b
```

which is inconsistent and increases git churn.