### PR TITLE
Support Ruby 2.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: .
   specs:
-    standard (0.0.40)
-      rubocop (~> 0.67.1)
+    standard (0.1.0)
+      rubocop (~> 0.71.0)
+      rubocop-performance (~> 1.3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -11,7 +12,7 @@ GEM
     coderay (1.1.2)
     docile (1.3.1)
     gimme (0.5.0)
-    jaro_winkler (1.5.2)
+    jaro_winkler (1.5.3)
     json (2.1.0)
     method_source (0.9.2)
     minitest (5.11.3)
@@ -21,24 +22,24 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    psych (3.1.0)
     rainbow (3.0.0)
     rake (12.3.2)
-    rubocop (0.67.2)
+    rubocop (0.71.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.5, != 2.5.1.1)
-      psych (>= 3.1.0)
+      parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.6)
-    ruby-progressbar (1.10.0)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-performance (1.3.0)
+      rubocop (>= 0.68.0)
+    ruby-progressbar (1.10.1)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    unicode-display_width (1.5.0)
+    unicode-display_width (1.6.0)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -279,8 +279,8 @@ for details.
 
 Because Standard wraps RuboCop, they share the same [runtime
 requirements](https://github.com/rubocop-hq/rubocop#compatibility)—currently,
-that's MRI 2.2 and newer. While Standard can't avoid this runtime requirement,
-it does allow you to lint codebases that target Ruby versions older than 2.2 by
+that's MRI 2.3 and newer. While Standard can't avoid this runtime requirement,
+it does allow you to lint codebases that target Ruby versions older than 2.3 by
 narrowing the ruleset somewhat.
 
 Standard will default to telling RuboCop to target the currently running version
@@ -288,7 +288,7 @@ of Ruby (by inspecting `RUBY_VERSION` at runtime. But if you want to lock it
 down, you can specify `ruby_version` in `.standard.yml`.
 
 ```
-ruby_version: 1.8.7
+ruby_version: 2.3.0
 ```
 
 See
@@ -297,11 +297,11 @@ for an example.
 
 It's a little confusing to consider, but the targeted Ruby version for linting
 may or may not match the version of the runtime (suppose you're on Ruby 2.5.1,
-but your library supports Ruby 2.2.0). In this case, specify `ruby_version` and
+but your library supports Ruby 2.3.0). In this case, specify `ruby_version` and
 you should be okay. However, note that if you target a _newer_ Ruby version than
 the runtime, RuboCop may behave in surprising or inconsistent ways.
 
-If you are targeting a Ruby older than 2.2 and run into an issue, check out
+If you are targeting a Ruby older than 2.3 and run into an issue, check out
 Standard's [version-specific RuboCop
 configurations](https://github.com/testdouble/standard/tree/master/config) and
 consider helping out by submitting a pull request if you find a rule that won't

--- a/config/base.yml
+++ b/config/base.yml
@@ -1,5 +1,7 @@
+require: rubocop-performance
+
 AllCops:
-  # Prevent RuboCop from exploding when it finds an older-than-2.2 .ruby-version
+  # Prevent RuboCop from exploding when it finds an older-than-2.3 .ruby-version
   TargetRubyVersion: 2.5
   DisabledByDefault: true
   Exclude: []
@@ -108,18 +110,18 @@ Layout/EndOfLine:
 Layout/ExtraSpacing:
   Enabled: true
 
-Layout/FirstParameterIndentation:
+Layout/IndentFirstArgument:
   Enabled: true
   EnforcedStyle: consistent
 
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   Enabled: true
   EnforcedStyle: consistent
 
 Layout/IndentAssignment:
   Enabled: true
 
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   Enabled: true
   EnforcedStyle: consistent
 
@@ -472,63 +474,6 @@ Naming/UncommunicativeBlockParamName:
   Enabled: true
 
 Naming/VariableName:
-  Enabled: true
-
-Performance/Caller:
-  Enabled: true
-
-Performance/CompareWithBlock:
-  Enabled: true
-
-Performance/Count:
-  Enabled: true
-
-Performance/Detect:
-  Enabled: true
-
-Performance/DoubleStartEndWith:
-  Enabled: true
-
-Performance/EndWith:
-  Enabled: true
-
-Performance/FixedSize:
-  Enabled: true
-
-Performance/FlatMap:
-  Enabled: true
-
-Performance/InefficientHashSearch:
-  Enabled: true
-
-Performance/RangeInclude:
-  Enabled: true
-
-Performance/RedundantMatch:
-  Enabled: true
-
-Performance/RedundantMerge:
-  Enabled: true
-
-Performance/RegexpMatch:
-  Enabled: true
-
-Performance/ReverseEach:
-  Enabled: true
-
-Performance/Size:
-  Enabled: true
-
-Performance/StartWith:
-  Enabled: true
-
-Performance/StringReplacement:
-  Enabled: true
-
-Performance/UnfreezeString:
-  Enabled: true
-
-Performance/UriDefaultParser:
   Enabled: true
 
 Rails/ActionFilter:

--- a/config/ruby-1.8.yml
+++ b/config/ruby-1.8.yml
@@ -1,8 +1,0 @@
-inherit_from: ./ruby-1.9.yml
-
-Style/Lambda:
-  Enabled: false
-
-Style/HashSyntax:
-  EnforcedStyle: hash_rockets
-

--- a/config/ruby-1.9.yml
+++ b/config/ruby-1.9.yml
@@ -1,4 +1,0 @@
-inherit_from: ./ruby-2.2.yml
-
-Style/Encoding:
-  Enabled: false

--- a/config/ruby-2.2.yml
+++ b/config/ruby-2.2.yml
@@ -1,8 +1,0 @@
-inherit_from: ./base.yml
-
-AllCops:
-  TargetRubyVersion: 2.2
-
-Layout:
-  IndentHeredoc:
-    Enabled: false

--- a/config/ruby-2.3.yml
+++ b/config/ruby-2.3.yml
@@ -1,0 +1,4 @@
+inherit_from: ./base.yml
+
+AllCops:
+  TargetRubyVersion: 2.3

--- a/lib/standard/creates_config_store/assigns_rubocop_yaml.rb
+++ b/lib/standard/creates_config_store/assigns_rubocop_yaml.rb
@@ -10,12 +10,8 @@ class Standard::CreatesConfigStore
     private
 
     def rubocop_yaml_path(desired_version)
-      file_name = if desired_version < Gem::Version.new("1.9")
-        "ruby-1.8.yml"
-      elsif desired_version < Gem::Version.new("2.0")
-        "ruby-1.9.yml"
-      elsif desired_version < Gem::Version.new("2.3")
-        "ruby-2.2.yml"
+      file_name = if desired_version < Gem::Version.new("2.4")
+        "ruby-2.3.yml"
       else
         "base.yml"
       end

--- a/lib/standard/creates_config_store/sets_target_ruby_version.rb
+++ b/lib/standard/creates_config_store/sets_target_ruby_version.rb
@@ -9,7 +9,7 @@ class Standard::CreatesConfigStore
     private
 
     def max_rubocop_supported_version(desired_version)
-      rubocop_supported_version = Gem::Version.new("2.2")
+      rubocop_supported_version = Gem::Version.new("2.3")
       if desired_version < rubocop_supported_version
         rubocop_supported_version
       else

--- a/lib/standard/version.rb
+++ b/lib/standard/version.rb
@@ -1,3 +1,3 @@
 module Standard
-  VERSION = Gem::Version.new("0.0.40")
+  VERSION = Gem::Version.new("0.1.0")
 end

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.67.1"
+  spec.add_dependency "rubocop", "~> 0.71.0"
+  spec.add_dependency "rubocop-performance", "~> 1.3.0"
 
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/test/fixture/runner/agreeable.rb
+++ b/test/fixture/runner/agreeable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 def add(left, right)
   left + right
 end

--- a/test/standard/builds_config_test.rb
+++ b/test/standard/builds_config_test.rb
@@ -49,7 +49,7 @@ class Standard::BuildsConfigTest < UnitTest
     ), result.rubocop_options
 
     expected_config = RuboCop::ConfigStore.new.tap do |config_store|
-      config_store.options_config = path("config/ruby-1.8.yml")
+      config_store.options_config = path("config/ruby-2.3.yml")
       options_config = config_store.instance_variable_get("@options_config")
       options_config["AllCops"]["Exclude"] |= [path("test/fixture/config/y/monkey/**/*")]
       options_config["Fake/Lol"] = {"Exclude" => [path("test/fixture/config/y/neat/cool.rb")]}
@@ -65,14 +65,6 @@ class Standard::BuildsConfigTest < UnitTest
     assert_equal config_store("test/fixture/config/x").dup.tap { |config_store|
       config_store["AllCops"]["Exclude"] |= [path("test/fixture/config/x/pants/**/*")]
     }, result.rubocop_config_store.for("").to_h
-  end
-
-  def test_19
-    result = @subject.call([], path("test/fixture/config/w"))
-
-    assert_equal DEFAULT_OPTIONS, result.rubocop_options
-
-    assert_equal config_store("test/fixture/config/w", "config/ruby-1.9.yml", 2.2), result.rubocop_config_store.for("").to_h
   end
 
   def test_specified_standard_yaml_overrides_local

--- a/test/standard/detects_fixability_test.rb
+++ b/test/standard/detects_fixability_test.rb
@@ -20,7 +20,7 @@ class Standard::DetectsFixabilityTest < UnitTest
   end
 
   def test_can_find_a_config_option_for_everything_we_prescribe_with_asploding
-    our_cop_names = YAML.load_file("config/base.yml").keys - ["AllCops"]
+    our_cop_names = YAML.load_file("config/base.yml").keys - ["AllCops", "require"]
 
     result = @subject.call(our_cop_names.map { |cop_name| Offense.new(cop_name) })
 

--- a/test/standard/runners/rubocop_test.rb
+++ b/test/standard/runners/rubocop_test.rb
@@ -47,14 +47,17 @@ class Standard::Runners::RubocopTest < UnitTest
 
     expected_out = <<-OUT.gsub(/^ {6}/, "")
       == test/fixture/runner/agreeable.rb ==
+      C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
       C:  1:  1: [Corrected] Style/SingleLineMethods: Avoid single-line method definitions.
-      C:  1:  5: Naming/MethodName: Use snake_case for method names.
       C:  1:  8: [Corrected] Layout/SpaceAfterSemicolon: Space missing after semicolon.
-      C:  1:  8: [Corrected] Style/Semicolon: Do not use semicolons to terminate expressions.
-      C:  1:  9: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
+      C:  3:  5: Naming/MethodName: Use snake_case for method names.
+      C:  3:  8: [Corrected] Style/Semicolon: Do not use semicolons to terminate expressions.
+      C:  3:  9: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
 
-      1 file inspected, 5 offenses detected, 4 offenses corrected
+      1 file inspected, 6 offenses detected, 5 offenses corrected
       ====================
+      # frozen_string_literal: true
+
       def Foo
         'hi'
       end


### PR DESCRIPTION
Addresses #119

With this version of Standard, we will be dropping support of Ruby <=
2.3 based on dependencies.

Rubocop does not support Ruby 2.7 until [this commit](https://github.com/rubocop-hq/rubocop/commit/c06cc51c541c3ac11ab529c909a8a0f90eefa892)
In that commit, the rubocop gemspec file requires Ruby >= 2.3.

We have also pulled in [rubocop-performance](https://github.com/rubocop-hq/rubocop-performance) instead of specifying performance cops in `config/base.yml`.