### PR TITLE
enforce %x(style invocation) because backticks `` are deprecated

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -737,7 +737,7 @@ Style/ColonMethodDefinition:
 
 Style/CommandLiteral:
   Enabled: true
-  EnforcedStyle: percent_x
+  EnforcedStyle: mixed
 
 Style/CommentedKeyword:
   Enabled: true

--- a/config/base.yml
+++ b/config/base.yml
@@ -737,6 +737,7 @@ Style/ColonMethodDefinition:
 
 Style/CommandLiteral:
   Enabled: true
+  EnforcedStyle: percent_x
 
 Style/CommentedKeyword:
   Enabled: true


### PR DESCRIPTION
Not a lot of people know/realize this, but Matz & ruby-core are deprecating backticks for running system commands and planning to eliminate them in Ruby 3 to free up the ` character for future syntax features. ([RedMine issue](https://bugs.ruby-lang.org/issues/14385))

As a result I think it's prudent that standard start enforcing the future-proof shorthand for invoking system commands