### PR TITLE
Set rubocop setting to disable extra spacing for alignment

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -137,7 +137,7 @@ Layout/EndOfLine:
 
 Layout/ExtraSpacing:
   Enabled: true
-  AllowForAlignment: true
+  AllowForAlignment: false
   AllowBeforeTrailingComments: false
   ForceEqualSignAlignment: false
 


### PR DESCRIPTION
Fixes #127

Related links:

https://docs.rubocop.org/en/stable/cops_layout/#layoutextraspacing
https://github.com/rubocop-hq/rubocop/issues/7269