### PR TITLE
bumpb rubocop version to 0.75

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     standard (0.1.4)
-      rubocop (~> 0.72.0)
+      rubocop (~> 0.73.0)
       rubocop-performance (~> 1.4.0)
 
 GEM
@@ -16,15 +16,15 @@ GEM
     json (2.1.0)
     method_source (0.9.2)
     minitest (5.11.3)
-    parallel (1.17.0)
-    parser (2.6.4.1)
+    parallel (1.18.0)
+    parser (2.6.5.0)
       ast (~> 2.4.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rainbow (3.0.0)
     rake (12.3.2)
-    rubocop (0.72.0)
+    rubocop (0.73.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     standard (0.1.4)
-      rubocop (~> 0.73.0)
+      rubocop (~> 0.74.0)
       rubocop-performance (~> 1.4.0)
 
 GEM
@@ -24,7 +24,7 @@ GEM
       method_source (~> 0.9.0)
     rainbow (3.0.0)
     rake (12.3.2)
-    rubocop (0.73.0)
+    rubocop (0.74.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     standard (0.1.4)
-      rubocop (~> 0.74.0)
-      rubocop-performance (~> 1.4.0)
+      rubocop (~> 0.75.0)
+      rubocop-performance (~> 1.5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -24,14 +24,14 @@ GEM
       method_source (~> 0.9.0)
     rainbow (3.0.0)
     rake (12.3.2)
-    rubocop (0.74.0)
+    rubocop (0.75.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-performance (1.4.1)
+    rubocop-performance (1.5.0)
       rubocop (>= 0.71.0)
     ruby-progressbar (1.10.1)
     simplecov (0.16.1)

--- a/config/base.yml
+++ b/config/base.yml
@@ -568,11 +568,9 @@ Performance/CompareWithBlock:
 
 Performance/Count:
   Enabled: true
-  SafeMode: true
 
 Performance/Detect:
   Enabled: true
-  SafeMode: true
 
 Performance/DoubleStartEndWith:
   Enabled: true

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.72.0"
+  spec.add_dependency "rubocop", "~> 0.73.0"
   spec.add_dependency "rubocop-performance", "~> 1.4.0"
 
   spec.add_development_dependency "bundler", "~> 1.17"

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.73.0"
+  spec.add_dependency "rubocop", "~> 0.74.0"
   spec.add_dependency "rubocop-performance", "~> 1.4.0"
 
   spec.add_development_dependency "bundler", "~> 1.17"

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.74.0"
-  spec.add_dependency "rubocop-performance", "~> 1.4.0"
+  spec.add_dependency "rubocop", "~> 0.75.0"
+  spec.add_dependency "rubocop-performance", "~> 1.5.0"
 
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/test/standard/runners/rubocop_test.rb
+++ b/test/standard/runners/rubocop_test.rb
@@ -50,11 +50,12 @@ class Standard::Runners::RubocopTest < UnitTest
       C:  1:  1: [Corrected] Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
       C:  1:  1: [Corrected] Style/SingleLineMethods: Avoid single-line method definitions.
       C:  1:  8: [Corrected] Layout/SpaceAfterSemicolon: Space missing after semicolon.
+      C:  2:  1: [Corrected] Layout/EmptyLineAfterMagicComment: Add an empty line after magic comments.
+      C:  2:  8: [Corrected] Style/Semicolon: Do not use semicolons to terminate expressions.
+      C:  2:  9: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
       C:  3:  5: Naming/MethodName: Use snake_case for method names.
-      C:  3:  8: [Corrected] Style/Semicolon: Do not use semicolons to terminate expressions.
-      C:  3:  9: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
 
-      1 file inspected, 6 offenses detected, 5 offenses corrected
+      1 file inspected, 7 offenses detected, 6 offenses corrected
       ====================
       # frozen_string_literal: true
 


### PR DESCRIPTION
issue: #139 . 

This PR moves us to depend on rubocop 0.75, in order to catch bug fixes. The one I'm specifically interested in is https://github.com/rubocop-hq/rubocop/issues/7170, but i thought it might be helpful to get us all the way up to date. 

Changes required:

* nothing required to move from 0.72 -> 0.73 (test suite passed with no issue)
* nothing required to move from 0.73 -> 0.74 (test suite passed with no issue)
* following changes required to move from 0.74 -> 0.75:
  * remove use of SafeMode parameters for `Performance/Count` and `Performance/Detect`, as these were marked as removed. they were removed in ` rubocop-performance v1.5.0` (see https://github.com/rubocop-hq/rubocop-performance/issues/69#issuecomment-510927912 for details), and marked as removed in https://github.com/rubocop-hq/rubocop/pull/7341
  * test output change in `test/standard/runners/rubocop_test.rb`. To my untrained eye, the changes do not seem semantically meaningful. 

If we are concerned about the changes necessary to get the move to 0.75 to work, happy to revert those and only bump to 0.74. 

Thanks! 