### PR TITLE
Ignore the /vendor directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,9 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "simplecov"
 SimpleCov.start
+SimpleCov.start do
+  add_filter "vendor"
+end
 
 require "standard"
 require "gimme"


### PR DESCRIPTION
When the support gems are installed in the `/vendor` directory[1] the gems are included in the test coverage report output to `coverage/index.html`


We want the test coverage report to only include the `standard` code.

This PR adds an exclusion to the simplecov configuration so that the external gem code is not included in the code coverage report.

It also adds `/vendor/` to the `.gitignore` file.

Note: It could be argued that this change does not belong in the main repository and this could be handled entirely by local branch configuration, in which case just close this PR.

[1]  Using `$ bundle install --path vendor/bundle` (see: https://bundler.io/bundle_install.html)

