### PR TITLE
Improve test coverage for semantic_blocks.rb

### DIFF
--- a/test/standard/cop/semantic_blocks_test.rb
+++ b/test/standard/cop/semantic_blocks_test.rb
@@ -57,4 +57,12 @@ class RuboCop::Cop::Standard::SemanticBlocksTest < UnitTest
       end
     RUBY
   end
+
+  def test_method_with_arguments_without_parentheses_multi_line_block_curly_braces
+    assert_no_offense @cop, <<-RUBY
+      some_method argument, another_argument { |block_argument|
+        puts "curly braces should be allowed here"
+      }
+    RUBY
+  end
 end


### PR DESCRIPTION
Add test coverage for:
```
        # If there are no parentheses around the arguments, then braces
        # and do-end have different meaning due to how they bind, so we
        # allow either.
             ignore_node(block)
```

https://github.com/testdouble/standard/blob/cc8d2feed0507904393ea4e1b0611525e6167633/lib/standard/cop/semantic_blocks.rb#L15

Before: Coverage 705 / 719 LOC (98.05%)
After: Coverage 710 / 721 LOC (98.47%)


Note: While I was working out how to test this I discovered some inconsistencies in how various combinations of curly braces/(do/end)/mutli-line blocks/single-line blocks are treated. I will address these in more detail in a separate issue or PR.
