### PR TITLE
Testing SemanticBlocks: Add test for ignored_method

### DIFF
--- a/test/standard/cop/semantic_blocks_test.rb
+++ b/test/standard/cop/semantic_blocks_test.rb
@@ -65,4 +65,12 @@ class RuboCop::Cop::Standard::SemanticBlocksTest < UnitTest
       }
     RUBY
   end
+
+  def test_accepts_a_multiline_functional_block_with_do_end_if_it_is_an_ignored_method
+    assert_no_offense @cop, <<-RUBY
+      foo = lambda do
+        puts 42
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Adds a unit test that executes the `ignored_method?` check.
See: https://github.com/testdouble/standard/blob/f6896ac8d79a5697d73ba1b80f60449698bbed86/lib/standard/cop/semantic_blocks.rb#L104L105

The methods that are ignored are configured as part of the cop
SemanticBlocks configuration.
[/config/base.yml](https://github.com/testdouble/standard/blob/f6896ac8d79a5697d73ba1b80f60449698bbed86/config/base.yml#L671)

Test coverage:

Before: 710 / 721 LOC (98.47%) covered.
After: 713 / 723 LOC (98.62%) covered.

(The extra 2 lines here are due to the test files themselves being
included in the coverage report. Whether this is a good thing is a
separate question.)