### PR TITLE
Bump Rubocop to 0.76.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     standard (0.1.6)
-      rubocop (~> 0.75.0)
-      rubocop-performance (~> 1.5.0)
+      rubocop (~> 0.77.0)
+      rubocop-performance (~> 1.5.1)
 
 GEM
   remote: https://rubygems.org/
@@ -16,7 +16,7 @@ GEM
     json (2.1.0)
     method_source (0.9.2)
     minitest (5.11.3)
-    parallel (1.18.0)
+    parallel (1.19.1)
     parser (2.6.5.0)
       ast (~> 2.4.0)
     pry (0.12.2)
@@ -24,14 +24,14 @@ GEM
       method_source (~> 0.9.0)
     rainbow (3.0.0)
     rake (12.3.2)
-    rubocop (0.75.1)
+    rubocop (0.77.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-performance (1.5.0)
+    rubocop-performance (1.5.1)
       rubocop (>= 0.71.0)
     ruby-progressbar (1.10.1)
     simplecov (0.16.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     standard (0.1.6)
       rubocop (~> 0.77.0)
       rubocop-performance (~> 1.5.1)
+      rubocop-rails
 
 GEM
   remote: https://rubygems.org/
@@ -22,6 +23,7 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    rack (2.0.7)
     rainbow (3.0.0)
     rake (12.3.2)
     rubocop (0.77.0)
@@ -33,6 +35,9 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     rubocop-performance (1.5.1)
       rubocop (>= 0.71.0)
+    rubocop-rails (2.4.0)
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
     ruby-progressbar (1.10.1)
     simplecov (0.16.1)
       docile (~> 1.1)

--- a/config/base.yml
+++ b/config/base.yml
@@ -24,20 +24,20 @@ Layout/AccessModifierIndentation:
   EnforcedStyle: indent
   IndentationWidth: ~
 
-Layout/AlignArguments:
+Layout/ArgumentAlignment:
   Enabled: true
   EnforcedStyle: with_fixed_indentation
 
-Layout/AlignArray:
+Layout/ArrayAlignment:
   Enabled: true
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: true
   EnforcedHashRocketStyle: key
   EnforcedColonStyle: key
   EnforcedLastArgumentHashStyle: always_inspect
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   Enabled: true
   EnforcedStyle: with_fixed_indentation
   IndentationWidth: ~
@@ -138,26 +138,26 @@ Layout/ExtraSpacing:
   AllowBeforeTrailingComments: false
   ForceEqualSignAlignment: false
 
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   Enabled: true
   EnforcedStyle: consistent
   IndentationWidth: ~
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   Enabled: true
   EnforcedStyle: consistent
   IndentationWidth: ~
 
-Layout/IndentAssignment:
+Layout/AssignmentIndentation:
   Enabled: true
   IndentationWidth: ~
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   Enabled: true
   EnforcedStyle: consistent
   IndentationWidth: ~
 
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: true
   EnforcedStyle: squiggly
 
@@ -173,7 +173,7 @@ Layout/IndentationWidth:
 Layout/InitialIndentation:
   Enabled: true
 
-Layout/LeadingBlankLines:
+Layout/LeadingEmptyLines:
   Enabled: true
 
 Layout/LeadingCommentSpace:
@@ -305,7 +305,7 @@ Layout/Tab:
   Enabled: true
   IndentationWidth: ~
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: true
   EnforcedStyle: final_newline
 
@@ -344,7 +344,7 @@ Lint/DuplicateCaseCondition:
 Lint/DuplicateMethods:
   Enabled: true
 
-Lint/DuplicatedKey:
+Lint/DuplicateHashKey:
   Enabled: true
 
 Lint/EachWithObjectArgument:
@@ -410,7 +410,7 @@ Lint/MissingCopEnableDirective:
   Enabled: true
   MaximumRangeSize: .inf
 
-Lint/MultipleCompare:
+Lint/MultipleComparison:
   Enabled: true
 
 Lint/NestedMethodDefinition:
@@ -460,7 +460,7 @@ Lint/ReturnInVoidContext:
 
 Lint/SafeNavigationChain:
   Enabled: true
-  Whitelist:
+  AllowedMethods:
     - present?
     - blank?
     - presence
@@ -469,7 +469,7 @@ Lint/SafeNavigationChain:
 
 Lint/SafeNavigationConsistency:
   Enabled: true
-  Whitelist:
+  AllowedMethods:
     - present?
     - blank?
     - presence
@@ -483,7 +483,7 @@ Lint/ShadowedArgument:
 Lint/ShadowedException:
   Enabled: true
 
-Lint/StringConversionInInterpolation:
+Lint/RedundantStringCoercion:
   Enabled: true
 
 Lint/Syntax:
@@ -495,10 +495,10 @@ Lint/UnderscorePrefixedVariableName:
 Lint/UnifiedInteger:
   Enabled: true
 
-Lint/UnneededRequireStatement:
+Lint/RedundantRequireStatement:
   Enabled: true
 
-Lint/UnneededSplatExpansion:
+Lint/RedundantSplatExpansion:
   Enabled: true
 
 Lint/UnreachableCode:
@@ -546,7 +546,7 @@ Naming/MethodName:
   Enabled: true
   EnforcedStyle: snake_case
 
-Naming/UncommunicativeBlockParamName:
+Naming/BlockParameterName:
   Enabled: true
   MinNameLength: 1
   AllowNamesEndingInNumbers: true
@@ -842,7 +842,7 @@ Style/NestedModifier:
 
 Style/NestedParenthesizedCalls:
   Enabled: true
-  Whitelist:
+  AllowedMethods:
     - be
     - be_a
     - be_an
@@ -952,7 +952,7 @@ Style/RescueStandardError:
 Style/SafeNavigation:
   Enabled: true
   ConvertCodeThatCanStartToReturnNil: false
-  Whitelist:
+  AllowedMethods:
     - present?
     - blank?
     - presence
@@ -1026,7 +1026,7 @@ Style/TrivialAccessors:
   AllowPredicates: true
   AllowDSLWriters: false
   IgnoreClassMethods: false
-  Whitelist:
+  AllowedMethod:
     - to_ary
     - to_a
     - to_c
@@ -1048,19 +1048,19 @@ Style/TrivialAccessors:
 Style/UnlessElse:
   Enabled: true
 
-Style/UnneededCapitalW:
+Style/RedundantCapitalW:
   Enabled: true
 
-Style/UnneededCondition:
+Style/RedundantCondition:
   Enabled: true
 
-Style/UnneededInterpolation:
+Style/RedundantInterpolation:
   Enabled: true
 
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: true
 
-Style/UnneededSort:
+Style/RedundantSort:
   Enabled: true
 
 Style/UnpackFirst:

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -1,0 +1,511 @@
+inherit_from: ./base.yml
+
+require:
+  - rubocop-performance
+  - rubocop-rails
+
+AllCops:
+  # What version of Rails is the inspected code using?  If a value is specified
+  # for TargetRailsVersion then it is used.  Acceptable values are specificed
+  # as a float (i.e. 5.1); the patch version of Rails should not be included.
+  # If TargetRailsVersion is not set, RuboCop will parse the Gemfile.lock or
+  # gems.locked file to find the version of Rails that has been bound to the
+  # application.  If neither of those files exist, RuboCop will use Rails 5.0
+  # as the default.
+  TargetRailsVersion: ~
+
+Rails/ActionFilter:
+  Description: 'Enforces consistent use of action filter methods.'
+  Enabled: true
+  VersionAdded: '0.19'
+  EnforcedStyle: action
+  SupportedStyles:
+    - action
+    - filter
+  Include:
+    - app/controllers/**/*.rb
+
+Rails/ActiveRecordAliases:
+  Description: >-
+                  Avoid Active Record aliases:
+                  Use `update` instead of `update_attributes`.
+                  Use `update!` instead of `update_attributes!`.
+  Enabled: true
+  VersionAdded: '0.53'
+  SafeAutoCorrect: false
+
+Rails/ActiveRecordOverride:
+  Description: >-
+                  Check for overriding Active Record methods instead of using
+                  callbacks.
+  Enabled: true
+  VersionAdded: '0.67'
+  Include:
+    - app/models/**/*.rb
+
+Rails/ActiveSupportAliases:
+  Description: >-
+                  Avoid ActiveSupport aliases of standard ruby methods:
+                  `String#starts_with?`, `String#ends_with?`,
+                  `Array#append`, `Array#prepend`.
+  Enabled: true
+  VersionAdded: '0.48'
+
+Rails/ApplicationController:
+  Description: 'Check that controllers subclass ApplicationController.'
+  Enabled: true
+  VersionAdded: '2.4'
+
+Rails/ApplicationJob:
+  Description: 'Check that jobs subclass ApplicationJob.'
+  Enabled: true
+  VersionAdded: '0.49'
+
+Rails/ApplicationMailer:
+  Description: 'Check that mailers subclass ApplicationMailer.'
+  Enabled: true
+  VersionAdded: '2.4'
+
+Rails/ApplicationRecord:
+  Description: 'Check that models subclass ApplicationRecord.'
+  Enabled: true
+  VersionAdded: '0.49'
+
+Rails/AssertNot:
+  Description: 'Use `assert_not` instead of `assert !`.'
+  Enabled: true
+  VersionAdded: '0.56'
+  Include:
+    - '**/test/**/*'
+
+Rails/BelongsTo:
+  Description: >-
+                  Use `optional: true` instead of `required: false` for
+                  `belongs_to` relations'
+  Enabled: true
+  VersionAdded: '0.62'
+
+Rails/Blank:
+  Description: 'Enforces use of `blank?`.'
+  Enabled: true
+  VersionAdded: '0.48'
+  VersionChanged: '0.67'
+  # Convert usages of `nil? || empty?` to `blank?`
+  NilOrEmpty: true
+  # Convert usages of `!present?` to `blank?`
+  NotPresent: true
+  # Convert usages of `unless present?` to `if blank?`
+  UnlessPresent: true
+
+Rails/BulkChangeTable:
+  Description: 'Check whether alter queries are combinable.'
+  Enabled: true
+  VersionAdded: '0.57'
+  Database: null
+  SupportedDatabases:
+    - mysql
+    - postgresql
+  Include:
+    - db/migrate/*.rb
+
+Rails/CreateTableWithTimestamps:
+  Description: >-
+                  Checks the migration for which timestamps are not included
+                  when creating a new table.
+  Enabled: true
+  VersionAdded: '0.52'
+  Include:
+    - db/migrate/*.rb
+
+Rails/Date:
+  Description: >-
+                  Checks the correct usage of date aware methods,
+                  such as Date.today, Date.current etc.
+  Enabled: true
+  VersionAdded: '0.30'
+  VersionChanged: '0.33'
+  # The value `strict` disallows usage of `Date.today`, `Date.current`,
+  # `Date#to_time` etc.
+  # The value `flexible` allows usage of `Date.current`, `Date.yesterday`, etc
+  # (but not `Date.today`) which are overridden by ActiveSupport to handle current
+  # time zone.
+  EnforcedStyle: flexible
+  SupportedStyles:
+    - strict
+    - flexible
+
+Rails/Delegate:
+  Description: 'Prefer delegate method for delegations.'
+  Enabled: true
+  VersionAdded: '0.21'
+  VersionChanged: '0.50'
+  # When set to true, using the target object as a prefix of the
+  # method name without using the `delegate` method will be a
+  # violation. When set to false, this case is legal.
+  EnforceForPrefixed: true
+
+Rails/DelegateAllowBlank:
+  Description: 'Do not use allow_blank as an option to delegate.'
+  Enabled: true
+  VersionAdded: '0.44'
+
+Rails/DynamicFindBy:
+  Description: 'Use `find_by` instead of dynamic `find_by_*`.'
+  StyleGuide: 'https://rails.rubystyle.guide#find_by'
+  Enabled: true
+  VersionAdded: '0.44'
+  Whitelist:
+    - find_by_sql
+
+Rails/EnumHash:
+  Description: 'Prefer hash syntax over array syntax when defining enums.'
+  StyleGuide: 'https://rails.rubystyle.guide#enums'
+  Enabled: true
+  VersionAdded: '2.3'
+  Include:
+    - app/models/**/*.rb
+
+Rails/EnumUniqueness:
+  Description: 'Avoid duplicate integers in hash-syntax `enum` declaration.'
+  Enabled: true
+  VersionAdded: '0.46'
+  Include:
+    - app/models/**/*.rb
+
+Rails/EnvironmentComparison:
+  Description: "Favor `Rails.env.production?` over `Rails.env == 'production'`"
+  Enabled: true
+  VersionAdded: '0.52'
+
+Rails/Exit:
+  Description: >-
+                  Favor `fail`, `break`, `return`, etc. over `exit` in
+                  application or library code outside of Rake files to avoid
+                  exits during unit testing or running in production.
+  Enabled: true
+  VersionAdded: '0.41'
+  Include:
+    - app/**/*.rb
+    - config/**/*.rb
+    - lib/**/*.rb
+  Exclude:
+    - lib/**/*.rake
+
+Rails/FilePath:
+  Description: 'Use `Rails.root.join` for file path joining.'
+  Enabled: true
+  VersionAdded: '0.47'
+  VersionChanged: '2.4'
+  EnforcedStyle: slashes
+  SupportedStyles:
+    - slashes
+    - arguments
+
+Rails/FindBy:
+  Description: 'Prefer find_by over where.first.'
+  StyleGuide: 'https://rails.rubystyle.guide#find_by'
+  Enabled: true
+  VersionAdded: '0.30'
+  Include:
+    - app/models/**/*.rb
+
+Rails/FindEach:
+  Description: 'Prefer all.find_each over all.find.'
+  StyleGuide: 'https://rails.rubystyle.guide#find-each'
+  Enabled: true
+  VersionAdded: '0.30'
+  Include:
+    - app/models/**/*.rb
+
+Rails/HasAndBelongsToMany:
+  Description: 'Prefer has_many :through to has_and_belongs_to_many.'
+  StyleGuide: 'https://rails.rubystyle.guide#has-many-through'
+  Enabled: true
+  VersionAdded: '0.12'
+  Include:
+    - app/models/**/*.rb
+
+Rails/HasManyOrHasOneDependent:
+  Description: 'Define the dependent option to the has_many and has_one associations.'
+  StyleGuide: 'https://rails.rubystyle.guide#has_many-has_one-dependent-option'
+  Enabled: true
+  VersionAdded: '0.50'
+  Include:
+    - app/models/**/*.rb
+
+Rails/HelperInstanceVariable:
+  Description: 'Do not use instance variables in helpers'
+  Enabled: true
+  VersionAdded: '2.0'
+  Include:
+    - app/helpers/**/*.rb
+
+Rails/HttpPositionalArguments:
+  Description: 'Use keyword arguments instead of positional arguments in http method calls.'
+  Enabled: true
+  VersionAdded: '0.44'
+  Include:
+    - 'spec/**/*'
+    - 'test/**/*'
+
+Rails/HttpStatus:
+  Description: 'Enforces use of symbolic or numeric value to define HTTP status.'
+  Enabled: true
+  VersionAdded: '0.54'
+  EnforcedStyle: symbolic
+  SupportedStyles:
+    - numeric
+    - symbolic
+
+Rails/IgnoredSkipActionFilterOption:
+  Description: 'Checks that `if` and `only` (or `except`) are not used together as options of `skip_*` action filter.'
+  Reference: 'https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-_normalize_callback_options'
+  Enabled: true
+  VersionAdded: '0.63'
+  Include:
+    - app/controllers/**/*.rb
+
+Rails/InverseOf:
+  Description: 'Checks for associations where the inverse cannot be determined automatically.'
+  Enabled: true
+  VersionAdded: '0.52'
+  Include:
+    - app/models/**/*.rb
+
+Rails/LexicallyScopedActionFilter:
+  Description: "Checks that methods specified in the filter's `only` or `except` options are explicitly defined in the controller."
+  StyleGuide: 'https://rails.rubystyle.guide#lexically-scoped-action-filter'
+  Enabled: true
+  Safe: false
+  VersionAdded: '0.52'
+  Include:
+    - app/controllers/**/*.rb
+
+Rails/LinkToBlank:
+  Description: 'Checks that `link_to` with a `target: "_blank"` have a `rel: "noopener"` option passed to them.'
+  Reference:
+    - https://mathiasbynens.github.io/rel-noopener/
+    - https://html.spec.whatwg.org/multipage/links.html#link-type-noopener
+    - https://html.spec.whatwg.org/multipage/links.html#link-type-noreferrer
+  Enabled: true
+  VersionAdded: '0.62'
+
+Rails/NotNullColumn:
+  Description: 'Do not add a NOT NULL column without a default value'
+  Enabled: true
+  VersionAdded: '0.43'
+  Include:
+    - db/migrate/*.rb
+
+Rails/Output:
+  Description: 'Checks for calls to puts, print, etc.'
+  Enabled: true
+  VersionAdded: '0.15'
+  VersionChanged: '0.19'
+  Include:
+    - app/**/*.rb
+    - config/**/*.rb
+    - db/**/*.rb
+    - lib/**/*.rb
+
+Rails/OutputSafety:
+  Description: 'The use of `html_safe` or `raw` may be a security risk.'
+  Enabled: true
+  VersionAdded: '0.41'
+
+Rails/PluralizationGrammar:
+  Description: 'Checks for incorrect grammar when using methods like `3.day.ago`.'
+  Enabled: true
+  VersionAdded: '0.35'
+
+Rails/Presence:
+  Description: 'Checks code that can be written more easily using `Object#presence` defined by Active Support.'
+  Enabled: true
+  VersionAdded: '0.52'
+
+Rails/Present:
+  Description: 'Enforces use of `present?`.'
+  Enabled: true
+  VersionAdded: '0.48'
+  VersionChanged: '0.67'
+  # Convert usages of `!nil? && !empty?` to `present?`
+  NotNilAndNotEmpty: true
+  # Convert usages of `!blank?` to `present?`
+  NotBlank: true
+  # Convert usages of `unless blank?` to `if present?`
+  UnlessBlank: true
+
+Rails/RakeEnvironment:
+  Description: 'Set `:environment` task as a dependency to all rake task.'
+  Enabled: true
+  Safe: false
+  VersionAdded: '2.4'
+  Include:
+    - '**/Rakefile'
+    - '**/*.rake'
+
+Rails/ReadWriteAttribute:
+  Description: >-
+                 Checks for read_attribute(:attr) and
+                 write_attribute(:attr, val).
+  StyleGuide: 'https://rails.rubystyle.guide#read-attribute'
+  Enabled: true
+  VersionAdded: '0.20'
+  VersionChanged: '0.29'
+  Include:
+    - app/models/**/*.rb
+
+Rails/RedundantAllowNil:
+  Description: >-
+                 Finds redundant use of `allow_nil` when `allow_blank` is set to
+                 certain values in model validations.
+  Enabled: true
+  VersionAdded: '0.67'
+  Include:
+    - app/models/**/*.rb
+
+Rails/RedundantReceiverInWithOptions:
+  Description: 'Checks for redundant receiver in `with_options`.'
+  Enabled: true
+  VersionAdded: '0.52'
+
+Rails/ReflectionClassName:
+  Description: 'Use a string for `class_name` option value in the definition of a reflection.'
+  Enabled: true
+  VersionAdded: '0.64'
+
+Rails/RefuteMethods:
+  Description: 'Use `assert_not` methods instead of `refute` methods.'
+  Enabled: true
+  VersionAdded: '0.56'
+  Include:
+    - '**/test/**/*'
+
+Rails/RelativeDateConstant:
+  Description: 'Do not assign relative date to constants.'
+  Enabled: true
+  VersionAdded: '0.48'
+  VersionChanged: '0.59'
+  AutoCorrect: false
+
+Rails/RequestReferer:
+  Description: 'Use consistent syntax for request.referer.'
+  Enabled: true
+  VersionAdded: '0.41'
+  EnforcedStyle: referer
+  SupportedStyles:
+    - referer
+    - referrer
+
+Rails/ReversibleMigration:
+  Description: 'Checks whether the change method of the migration file is reversible.'
+  StyleGuide: 'https://rails.rubystyle.guide#reversible-migration'
+  Reference: 'https://api.rubyonrails.org/classes/ActiveRecord/Migration/CommandRecorder.html'
+  Enabled: true
+  VersionAdded: '0.47'
+  Include:
+    - db/migrate/*.rb
+
+Rails/SafeNavigation:
+  Description: "Use Ruby's safe navigation operator (`&.`) instead of `try!`"
+  Enabled: true
+  VersionAdded: '0.43'
+  # This will convert usages of `try` to use safe navigation as well as `try!`.
+  # `try` and `try!` work slightly differently. `try!` and safe navigation will
+  # both raise a `NoMethodError` if the receiver of the method call does not
+  # implement the intended method. `try` will not raise an exception for this.
+  ConvertTry: false
+
+Rails/SafeNavigationWithBlank:
+  Description: 'Avoid `foo&.blank?` in conditionals.'
+  Enabled: true
+  VersionAdded: '2.4'
+  # While the safe navigation operator is generally a good idea, when
+  # checking `foo&.blank?` in a conditional, `foo` being `nil` will actually
+  # do the opposite of what the author intends.
+  #
+  # foo&.blank? #=> nil
+  # foo.blank? #=> true
+  SafeAutoCorrect: false
+
+Rails/SaveBang:
+  Description: 'Identifies possible cases where Active Record save! or related should be used.'
+  StyleGuide: 'https://rails.rubystyle.guide#save-bang'
+  Enabled: false
+  VersionAdded: '0.42'
+  VersionChanged: '0.59'
+  AllowImplicitReturn: true
+  AllowedReceivers: []
+  SafeAutoCorrect: false
+
+Rails/ScopeArgs:
+  Description: 'Checks the arguments of ActiveRecord scopes.'
+  Enabled: true
+  VersionAdded: '0.19'
+  Include:
+    - app/models/**/*.rb
+
+Rails/SkipsModelValidations:
+  Description: >-
+                 Use methods that skips model validations with caution.
+                 See reference for more information.
+  Reference: 'https://guides.rubyonrails.org/active_record_validations.html#skipping-validations'
+  Enabled: true
+  VersionAdded: '0.47'
+  VersionChanged: '0.60'
+  Blacklist:
+    - decrement!
+    - decrement_counter
+    - increment!
+    - increment_counter
+    - toggle!
+    - touch
+    - update_all
+    - update_attribute
+    - update_column
+    - update_columns
+    - update_counters
+  Whitelist: []
+
+Rails/TimeZone:
+  Description: 'Checks the correct usage of time zone aware methods.'
+  StyleGuide: 'https://rails.rubystyle.guide#time'
+  Reference: 'http://danilenko.org/2012/7/6/rails_timezones'
+  Enabled: true
+  Safe: false
+  VersionAdded: '0.30'
+  VersionChanged: '0.68'
+  # The value `strict` means that `Time` should be used with `zone`.
+  # The value `flexible` allows usage of `in_time_zone` instead of `zone`.
+  EnforcedStyle: flexible
+  SupportedStyles:
+    - strict
+    - flexible
+
+Rails/UniqBeforePluck:
+  Description: 'Prefer the use of uniq or distinct before pluck.'
+  Enabled: true
+  VersionAdded: '0.40'
+  VersionChanged: '0.47'
+  EnforcedStyle: conservative
+  SupportedStyles:
+    - conservative
+    - aggressive
+  AutoCorrect: false
+
+Rails/UnknownEnv:
+  Description: 'Use correct environment name.'
+  Enabled: true
+  VersionAdded: '0.51'
+  Environments:
+    - development
+    - test
+    - production
+
+Rails/Validation:
+  Description: 'Use validates :attribute, hash of validations.'
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.41'
+  Include:
+    - app/models/**/*.rb

--- a/config/ruby-2.2.yml
+++ b/config/ruby-2.2.yml
@@ -4,5 +4,5 @@ AllCops:
   TargetRubyVersion: 2.3 # The oldest supported
 
 Layout:
-  IndentHeredoc:
+  HeredocIndentation:
     Enabled: false

--- a/lib/standard/creates_config_store/assigns_rubocop_yaml.rb
+++ b/lib/standard/creates_config_store/assigns_rubocop_yaml.rb
@@ -17,7 +17,7 @@ class Standard::CreatesConfigStore
       elsif desired_version < Gem::Version.new("2.3")
         "ruby-2.2.yml"
       else
-        "base.yml"
+        "rails.yml"
       end
 
       Pathname.new(__dir__).join("../../../config/#{file_name}")

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -1,4 +1,6 @@
-lib = File.expand_path("../lib", __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "standard/version"
 
@@ -11,20 +13,20 @@ Gem::Specification.new do |spec|
   spec.summary = "Ruby Style Guide, with linter & automatic code fixer"
   spec.homepage = "https://github.com/testdouble/standard"
 
-  spec.files = Dir.chdir(File.expand_path("..", __FILE__)) do
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.75.0"
-  spec.add_dependency "rubocop-performance", "~> 1.5.0"
+  spec.add_dependency "rubocop", "~> 0.77.0"
+  spec.add_dependency "rubocop-performance", "~> 1.5.1"
 
   spec.add_development_dependency "bundler", "~> 1.17"
+  spec.add_development_dependency "gimme"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "gimme"
 end

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rubocop", "~> 0.77.0"
   spec.add_dependency "rubocop-performance", "~> 1.5.1"
+  spec.add_dependency "rubocop-rails"
 
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "gimme"


### PR DESCRIPTION
Bumps Rubocop to latest released version, 0.76.0, including cop naming changes. 

**Note:** Using `AllowedMethod`, instead of plural `AllowedMethods` on the `Style/TrivialAccessors` cop is currently required, due to a typo bug in Rubocop 0.76.0. See https://github.com/rubocop-hq/rubocop/issues/7530

Couldn't work out why tests were failing, until I found that! :P