### PR TITLE
Bump Rubocop to 0.77.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     standard (0.1.6)
-      rubocop (~> 0.75.0)
-      rubocop-performance (~> 1.5.0)
+      rubocop (~> 0.77.0)
+      rubocop-performance (~> 1.5.1)
 
 GEM
   remote: https://rubygems.org/
@@ -16,7 +16,7 @@ GEM
     json (2.1.0)
     method_source (0.9.2)
     minitest (5.11.3)
-    parallel (1.18.0)
+    parallel (1.19.1)
     parser (2.6.5.0)
       ast (~> 2.4.0)
     pry (0.12.2)
@@ -24,14 +24,14 @@ GEM
       method_source (~> 0.9.0)
     rainbow (3.0.0)
     rake (12.3.2)
-    rubocop (0.75.1)
+    rubocop (0.77.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-performance (1.5.0)
+    rubocop-performance (1.5.1)
       rubocop (>= 0.71.0)
     ruby-progressbar (1.10.1)
     simplecov (0.16.1)

--- a/config/base.yml
+++ b/config/base.yml
@@ -24,20 +24,20 @@ Layout/AccessModifierIndentation:
   EnforcedStyle: indent
   IndentationWidth: ~
 
-Layout/AlignArguments:
+Layout/ArgumentAlignment:
   Enabled: true
   EnforcedStyle: with_fixed_indentation
 
-Layout/AlignArray:
+Layout/ArrayAlignment:
   Enabled: true
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: true
   EnforcedHashRocketStyle: key
   EnforcedColonStyle: key
   EnforcedLastArgumentHashStyle: always_inspect
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   Enabled: true
   EnforcedStyle: with_fixed_indentation
   IndentationWidth: ~
@@ -138,26 +138,26 @@ Layout/ExtraSpacing:
   AllowBeforeTrailingComments: false
   ForceEqualSignAlignment: false
 
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   Enabled: true
   EnforcedStyle: consistent
   IndentationWidth: ~
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   Enabled: true
   EnforcedStyle: consistent
   IndentationWidth: ~
 
-Layout/IndentAssignment:
+Layout/AssignmentIndentation:
   Enabled: true
   IndentationWidth: ~
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   Enabled: true
   EnforcedStyle: consistent
   IndentationWidth: ~
 
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: true
   EnforcedStyle: squiggly
 
@@ -173,7 +173,7 @@ Layout/IndentationWidth:
 Layout/InitialIndentation:
   Enabled: true
 
-Layout/LeadingBlankLines:
+Layout/LeadingEmptyLines:
   Enabled: true
 
 Layout/LeadingCommentSpace:
@@ -305,7 +305,7 @@ Layout/Tab:
   Enabled: true
   IndentationWidth: ~
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: true
   EnforcedStyle: final_newline
 
@@ -344,7 +344,7 @@ Lint/DuplicateCaseCondition:
 Lint/DuplicateMethods:
   Enabled: true
 
-Lint/DuplicatedKey:
+Lint/DuplicateHashKey:
   Enabled: true
 
 Lint/EachWithObjectArgument:
@@ -410,7 +410,7 @@ Lint/MissingCopEnableDirective:
   Enabled: true
   MaximumRangeSize: .inf
 
-Lint/MultipleCompare:
+Lint/MultipleComparison:
   Enabled: true
 
 Lint/NestedMethodDefinition:
@@ -460,7 +460,7 @@ Lint/ReturnInVoidContext:
 
 Lint/SafeNavigationChain:
   Enabled: true
-  Whitelist:
+  AllowedMethods:
     - present?
     - blank?
     - presence
@@ -469,7 +469,7 @@ Lint/SafeNavigationChain:
 
 Lint/SafeNavigationConsistency:
   Enabled: true
-  Whitelist:
+  AllowedMethods:
     - present?
     - blank?
     - presence
@@ -483,7 +483,7 @@ Lint/ShadowedArgument:
 Lint/ShadowedException:
   Enabled: true
 
-Lint/StringConversionInInterpolation:
+Lint/RedundantStringCoercion:
   Enabled: true
 
 Lint/Syntax:
@@ -495,10 +495,10 @@ Lint/UnderscorePrefixedVariableName:
 Lint/UnifiedInteger:
   Enabled: true
 
-Lint/UnneededRequireStatement:
+Lint/RedundantRequireStatement:
   Enabled: true
 
-Lint/UnneededSplatExpansion:
+Lint/RedundantSplatExpansion:
   Enabled: true
 
 Lint/UnreachableCode:
@@ -546,7 +546,7 @@ Naming/MethodName:
   Enabled: true
   EnforcedStyle: snake_case
 
-Naming/UncommunicativeBlockParamName:
+Naming/BlockParameterName:
   Enabled: true
   MinNameLength: 1
   AllowNamesEndingInNumbers: true
@@ -842,7 +842,7 @@ Style/NestedModifier:
 
 Style/NestedParenthesizedCalls:
   Enabled: true
-  Whitelist:
+  AllowedMethods:
     - be
     - be_a
     - be_an
@@ -952,7 +952,7 @@ Style/RescueStandardError:
 Style/SafeNavigation:
   Enabled: true
   ConvertCodeThatCanStartToReturnNil: false
-  Whitelist:
+  AllowedMethods:
     - present?
     - blank?
     - presence
@@ -1026,7 +1026,7 @@ Style/TrivialAccessors:
   AllowPredicates: true
   AllowDSLWriters: false
   IgnoreClassMethods: false
-  Whitelist:
+  AllowedMethod:
     - to_ary
     - to_a
     - to_c
@@ -1048,19 +1048,19 @@ Style/TrivialAccessors:
 Style/UnlessElse:
   Enabled: true
 
-Style/UnneededCapitalW:
+Style/RedundantCapitalW:
   Enabled: true
 
-Style/UnneededCondition:
+Style/RedundantCondition:
   Enabled: true
 
-Style/UnneededInterpolation:
+Style/RedundantInterpolation:
   Enabled: true
 
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: true
 
-Style/UnneededSort:
+Style/RedundantSort:
   Enabled: true
 
 Style/UnpackFirst:

--- a/config/ruby-2.2.yml
+++ b/config/ruby-2.2.yml
@@ -4,5 +4,5 @@ AllCops:
   TargetRubyVersion: 2.3 # The oldest supported
 
 Layout:
-  IndentHeredoc:
+  HeredocIndentation:
     Enabled: false

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.75.0"
-  spec.add_dependency "rubocop-performance", "~> 1.5.0"
+  spec.add_dependency "rubocop", "~> 0.77.0"
+  spec.add_dependency "rubocop-performance", "~> 1.5.1"
 
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
Bumps Rubocop to latest released version, 0.77.0, including cop naming changes.