### PR TITLE
No trailing commas in argument lists

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -1011,6 +1011,10 @@ Style/TrailingBodyOnMethodDefinition:
 Style/TrailingBodyOnModule:
   Enabled: true
 
+Style/TrailingCommaInArguments:
+  Enabled: true
+  EnforcedStyleForMultiline: no_comma
+
 Style/TrailingCommaInArrayLiteral:
   Enabled: true
   EnforcedStyleForMultiline: no_comma

--- a/test/fixture/cli/autocorrectable-bad.rb
+++ b/test/fixture/cli/autocorrectable-bad.rb
@@ -70,7 +70,7 @@ class AlignyStuff
       provider:              'AWS',
       aws_access_key_id:     ENV['S3_ACCESS_KEY'],
       aws_secret_access_key: ENV['S3_SECRET'],
-      region:                ENV['S3_REGION']
+      region:                ENV['S3_REGION'],
     )
   end
 


### PR DESCRIPTION
Will turn

```
doit(
  foo: "bar",
  baz: "qux",
)
```

into

```
doit(
  foo: "bar",
  baz: "qux"
)
```

Fixes #159.