### PR TITLE
Document how to create the spring binstub

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ the tool you're interested in. That aside, here are other known integrations asi
 from editor plugins:
 
 * [Pronto](https://github.com/julianrubisch/pronto-standardrb)
+* [Spring](https://github.com/lakim/spring-commands-standard)
 
 ## Contributing
 


### PR DESCRIPTION
Hey there,

Thanks for the great tool.
I wanted to speedup `standardrb`, especially when running in VS Code for linting and to format on save (needs https://github.com/rubyide/vscode-ruby/issues/548).

I created [spring-commands-standard](https://github.com/lakim/spring-commands-standard) to configure `spring` to generate the `bin/standardrb` binstub.

Example on a 13 lines file:

```shell
# Before
$ time bundle exec standardrb --fix path/to/file.rb
bundle exec standardrb --fix   1,33s user 0,35s system 102% cpu 1,650 total

# After
$ time bin/standardrb --fix path/to/file.rb
Running via Spring preloader in process 32323
bin/standardrb --fix   0,35s user 0,15s system 68% cpu 0,723 total
```

See the PR to update spring's README: https://github.com/rails/spring/pull/612