### PR TITLE
Don't break do/end blocks with `rescue` nodes

### DIFF
--- a/lib/standard/cop/semantic_blocks.rb
+++ b/lib/standard/cop/semantic_blocks.rb
@@ -114,6 +114,14 @@ module RuboCop::Cop
       end
 
       def correction_would_break_code?(node)
+        rescue_child_block?(node) || non_parenthesized_keyword_args?(node)
+      end
+
+      def rescue_child_block?(node)
+        node.children.any?(&:rescue_type?)
+      end
+
+      def non_parenthesized_keyword_args?(node)
         return unless node.keywords?
 
         node.send_node.arguments? && !node.send_node.parenthesized?

--- a/test/standard/cop/semantic_blocks_test.rb
+++ b/test/standard/cop/semantic_blocks_test.rb
@@ -67,6 +67,19 @@ class RuboCop::Cop::Standard::SemanticBlocksTest < UnitTest
     RUBY
   end
 
+  def test_braces_with_rescue_does_not_correct
+    assert_offense @cop, <<-RUBY
+      lulz = [:a].map do
+                      ^^ Prefer `{...}` over `do...end` for functional blocks.
+        :lol
+      rescue StandardError
+        :nolol
+      end
+    RUBY
+
+    assert_no_correction @cop
+  end
+
   def test_braces_with_side_effect_fails
     assert_offense @cop, <<-RUBY
       42.tap {


### PR DESCRIPTION
For example, changing:

```ruby
lulz = [:a].map do
  :lol
rescue StandardError
  :nolol
end
```

to

```ruby
lulz = [:a].map {
  :lol
rescue StandardError
  :nolol
}
```

will result in a SyntaxError.

When running Standard against our codebase, this was the only
error that was introduced. 