### PR TITLE
Support for global config

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ cannot be found by ascending the current working directory (i.e., against a
 temporary file buffer in your editor), you can specify the config location with
 `--config path/to/.standard.yml`.
 
+You can also set a global configuration by creating a `.standard_global.yml` in your home directory.
+
 ## What you might do if you're REALLY clever
 
 Because StandardRB is essentially a wrapper on top of

--- a/lib/standard/loads_yaml_config.rb
+++ b/lib/standard/loads_yaml_config.rb
@@ -7,15 +7,35 @@ module Standard
   class LoadsYamlConfig
     def initialize
       @parses_cli_option = ParsesCliOption.new
+      @global_config_dir = ENV["HOME"]
     end
 
     def call(argv, search_path)
       yaml_path = @parses_cli_option.call(argv, "--config") ||
         FileFinder.new.call(".standard.yml", search_path)
-      construct_config(yaml_path, load_standard_yaml(yaml_path))
+
+      # global config
+      global_yaml_path = FileFinder.new.call(".standard_global.yml", @global_config_dir)
+
+      standard_yaml = resolve_config(load_standard_yaml(global_yaml_path), load_standard_yaml(yaml_path))
+      construct_config(yaml_path, standard_yaml)
     end
 
     private
+
+    def resolve_config(global_config, custom_config)
+      keys = %w[ruby_version fix format parallel default_ignores]
+      config = global_config.slice(*keys).merge(custom_config.slice(*keys))
+
+      return config unless global_config["ignore"] || custom_config["ignore"]
+      # merge `ignore`
+      config["ignore"] = arrayify(custom_config["ignore"]).to_set
+        .merge(arrayify(global_config["ignore"]).to_set)
+        .to_a
+        .compact
+
+      config
+    end
 
     def load_standard_yaml(yaml_path)
       if yaml_path

--- a/test/fixture/config/t/.standard.yml
+++ b/test/fixture/config/t/.standard.yml
@@ -1,0 +1,9 @@
+fix: false
+ruby_version: 2.2
+ignore:
+  - hello/**/*
+  - neat/cool.rb:
+    - Fake/Hi
+    - Fake/Lol
+  - nest/file.rb:
+    - Fake/T

--- a/test/fixture/config/t/.standard_global.yml
+++ b/test/fixture/config/t/.standard_global.yml
@@ -1,0 +1,10 @@
+fix: true
+parallel: true
+format: progress
+ruby_version: 1.8.7
+default_ignores: false
+ignore:
+  - monkey/**/*
+  - neat/cool.rb:
+    - Fake/Lol
+    - Fake/Kek

--- a/test/fixture/config/u/.standard_global.yml
+++ b/test/fixture/config/u/.standard_global.yml
@@ -1,0 +1,11 @@
+fix: true
+parallel: true
+format: progress
+ruby_version: 1.8.7
+default_ignores: false
+ignore:
+  - monkey/**/*
+  - neat/cool.rb:
+    - Fake/Lol
+    - Fake/Kek
+


### PR DESCRIPTION
I am trying to exclude a file without having to list it in the repo's standard.yml file. That directory is included in my global gitignore file so it gets to be ignored, and I do not want to add it to the repo's standard.yml file exclusion list (for the same reason why I added it to the global gitignore file vs the repo's gitignore file).

This PR adds that basic functionality by looking for a `.standard_global.yml` file in the home directory.