### PR TITLE
Add given and given! to list of functional block methods

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -667,6 +667,8 @@ Standard/SemanticBlocks:
     # Rails
     - transaction
   FunctionalMethods:
+    - given
+    - given!
     - let
     - let!
     - subject


### PR DESCRIPTION
Hello! 👋

I found an unexpected offence arise when writing Capybara “feature” specs (i.e. `RSpec.feature "blah" do ...`):

```
spec/path/to/index_spec.rb:4:53: C: Standard/SemanticBlocks: Prefer do...end over {...} for procedural blocks.
--
  | given!(:some_thing) {
```

`given` and `given!` are provided by Capybara as aliases for `let` and `let!` respectively, and are often used in Capybara “feature” specs.

The [Capybara README](https://github.com/teamcapybara/capybara#using-capybara-with-rspec) introduces them as such:

> `feature` is in fact just an alias for `describe ..., type: :feature`, `background` is an alias for `before`, `scenario` for `it`, and `given`/`given!` aliases for `let`/`let!`, respectively.

Given (heh) we have `let` and `let!` in the list of functional block methods, it would make sense to include `given` and `given!` as well, right? (Particularly given we have the capitalised versions in place to support the standalone rspec-given gem)

At the time of adding this, I briefly considered adding `scenario` to the list of ignored methods, alongside its aliased counterpart, `it`, but I think that for Capybara-style "feature specs", its would be highly unusual to have a single-line `scenario` invocation, so I decided to leave it out.

Thanks for standard!