### PR TITLE
adding standardrb plugin for guard in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ from editor plugins:
 
 * [Pronto](https://github.com/julianrubisch/pronto-standardrb)
 * [Spring](https://github.com/lakim/spring-commands-standard)
+* [Guard](https://github.com/JodyVanden/guard-standardrb)
 
 ## Contributing
 


### PR DESCRIPTION
This PR adds a link to the repo of a gem using standardrb with the gem guard

Once installed, you can run guard in your terminal and it will output any errors on the files modified by the user.