### PR TITLE
Print TODO warning as frontmatter

### DIFF
--- a/lib/standard/formatter.rb
+++ b/lib/standard/formatter.rb
@@ -17,6 +17,10 @@ module Standard
       @any_uncorrected_offenses = false
     end
 
+    def started(_target_files)
+      print_todo_warning
+    end
+
     def file_finished(file, offenses)
       return unless (uncorrected_offenses = offenses.reject(&:corrected?)).any?
       @any_uncorrected_offenses = true
@@ -30,7 +34,6 @@ module Standard
     end
 
     def finished(_)
-      print_todo_warning
       print_call_for_feedback if @any_uncorrected_offenses
     end
 

--- a/test/standard/formatter_test.rb
+++ b/test/standard/formatter_test.rb
@@ -122,7 +122,7 @@ class Standard::FormatterTest < UnitTest
   def test_prints_todo_warning
     mock_options = {todo_file: ".standard_todo.yml", todo_ignore_files: %w[file1.rb file2.rb]}
     @subject.stub :options, mock_options do
-      @subject.finished([@some_path])
+      @subject.started([@some_path])
 
       assert_equal <<-MESSAGE.gsub(/^ {8}/, ""), @io.string
         WARNING: this project is being migrated to standard gradually via `.standard_todo.yml` and is ignoring these files:


### PR DESCRIPTION
When we print a long TODO file as the next-to-last message for both failures and passes, failure output is harder to interpret. The fact that both failures and passes "look the same" at the bottom of one's terminal is proving a source of confusion for some folks on my team.