### PR TITLE
Style/FrozenStringLiteralComment always on

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -775,6 +775,11 @@ Style/For:
   Enabled: true
   EnforcedStyle: each
 
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always_true
+  AutoCorrect: true
+
 Style/GlobalVars:
   Enabled: true
   AllowedVariables: []

--- a/test/fixture/cli/unfixable-bad.rb
+++ b/test/fixture/cli/unfixable-bad.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Foo
   def stuff(id)
     if bar = Bar.find(id)

--- a/test/fixture/cli/unfixable-good.rb
+++ b/test/fixture/cli/unfixable-good.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Foo
   def stuff(id)
     if (bar = Bar.find(id))

--- a/test/fixture/project/a/lib/do_lint.rb
+++ b/test/fixture/project/a/lib/do_lint.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 useless_assignment = "LOL"

--- a/test/fixture/project/a/lib/foo/do_lint.rb
+++ b/test/fixture/project/a/lib/foo/do_lint.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 useless_assignment = "LOL"

--- a/test/fixture/project/a/lib/foo/tmp/do_lint.rb
+++ b/test/fixture/project/a/lib/foo/tmp/do_lint.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 useless_assignment = "LOL"

--- a/test/standard/cli_test.rb
+++ b/test/standard/cli_test.rb
@@ -23,7 +23,7 @@ class Standard::CliTest < UnitTest
     assert_empty fake_err.string
     assert_equal <<-OUTPUT.gsub(/^ {6}/, ""), fake_out.string
       standard: Use Ruby Standard Style (https://github.com/testdouble/standard)
-        test/fixture/cli/unfixable-bad.rb:3:12: Lint/AssignmentInCondition: Wrap assignment in parentheses if intentional
+        test/fixture/cli/unfixable-bad.rb:5:12: Lint/AssignmentInCondition: Wrap assignment in parentheses if intentional
 
       #{call_to_action_message}
     OUTPUT

--- a/test/standardrb_test.rb
+++ b/test/standardrb_test.rb
@@ -8,9 +8,9 @@ class StandardrbTest < UnitTest
     refute status.success?
     assert_same_lines <<-MSG.gsub(/^ {6}/, ""), stdout
       standard: Use Ruby Standard Style (https://github.com/testdouble/standard)
-        lib/foo/do_lint.rb:1:1: Lint/UselessAssignment: Useless assignment to variable - `useless_assignment`.
-        lib/foo/tmp/do_lint.rb:1:1: Lint/UselessAssignment: Useless assignment to variable - `useless_assignment`.
-        lib/do_lint.rb:1:1: Lint/UselessAssignment: Useless assignment to variable - `useless_assignment`.
+        lib/foo/do_lint.rb:3:1: Lint/UselessAssignment: Useless assignment to variable - `useless_assignment`.
+        lib/foo/tmp/do_lint.rb:3:1: Lint/UselessAssignment: Useless assignment to variable - `useless_assignment`.
+        lib/do_lint.rb:3:1: Lint/UselessAssignment: Useless assignment to variable - `useless_assignment`.
 
       #{call_to_action_message}
     MSG
@@ -29,8 +29,8 @@ class StandardrbTest < UnitTest
     refute status.success?
     assert_same_lines <<-MSG.gsub(/^ {6}/, ""), stdout
       standard: Use Ruby Standard Style (https://github.com/testdouble/standard)
-        do_lint.rb:1:1: Lint/UselessAssignment: Useless assignment to variable - `useless_assignment`.
-        tmp/do_lint.rb:1:1: Lint/UselessAssignment: Useless assignment to variable - `useless_assignment`.
+        do_lint.rb:3:1: Lint/UselessAssignment: Useless assignment to variable - `useless_assignment`.
+        tmp/do_lint.rb:3:1: Lint/UselessAssignment: Useless assignment to variable - `useless_assignment`.
 
       #{call_to_action_message}
     MSG


### PR DESCRIPTION
I think the frozen string literal comment should always be true, especially as ruby 3 comes down the line, and I've been manually going through my projects and adding the comment as I go. But it's hard to remember to always do it, so it'd be nice if standard added it for me. 

However I couldn't figure out how to actually get the auto correct to work for this, which is the test failure :/


links:
[docs](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/FrozenStringLiteralComment)
[disable enforcing no comment](https://github.com/testdouble/standard/pull/120)
[invert rules](https://github.com/testdouble/standard/commit/b5ed4db7137c0e8e5431266ed0ee1aa9f02a4848)