### PR TITLE
Rename comment directive to "standardrb"

### DIFF
--- a/lib/standard/rubocop/ext.rb
+++ b/lib/standard/rubocop/ext.rb
@@ -5,4 +5,12 @@ module RuboCop
       "Wrap assignment in parentheses if intentional"
     end
   end
+
+  class CommentConfig
+    remove_const :COMMENT_DIRECTIVE_REGEXP
+    COMMENT_DIRECTIVE_REGEXP = Regexp.new(
+      ('# standardrb : ((?:disable|enable|todo))\b ' + COPS_PATTERN)
+        .gsub(" ", '\s*')
+    )
+  end
 end

--- a/test/fixture/comment_directive_test/disabled.rb
+++ b/test/fixture/comment_directive_test/disabled.rb
@@ -1,0 +1,9 @@
+# standardrb:disable Layout/IndentationWidth
+def foo
+    123
+end
+# standardrb:enable Layout/IndentationWidth
+
+def bar
+    456
+end

--- a/test/standard/comment_directive_test.rb
+++ b/test/standard/comment_directive_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+require "fileutils"
+
+class Standard::CommentDirectiveTest < UnitTest
+  def test_comment_directive
+    fake_out, fake_err, exit_code = do_with_fake_io {
+      Standard::Cli.new(["test/fixture/comment_directive_test/disabled.rb"]).run
+    }
+
+    refute_equal 0, exit_code
+    assert_empty fake_err.string
+    assert_equal <<-OUTPUT.gsub(/^ {6}/, ""), fake_out.string
+      standard: Use Ruby Standard Style (https://github.com/testdouble/standard)
+      standard: Run `standardrb --fix` to automatically fix some problems.
+        test/fixture/comment_directive_test/disabled.rb:8:1: Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
+
+      #{call_to_action_message}
+    OUTPUT
+  end
+
+  private
+
+  def call_to_action_message
+    Standard::Formatter::CALL_TO_ACTION_MESSAGE.chomp
+  end
+end


### PR DESCRIPTION
I had a quick look at making this a configurable option in RuboCop but it seems non-trival to implement. 

I've opened [an issue over at RuboCop](https://github.com/rubocop-hq/rubocop/issues/8181) about making it configurable on their end.

Fixes https://github.com/testdouble/standard/issues/184.