### PR TITLE
Update rubocop to 0.90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   * [`Lint/DuplicateRequire`](https://github.com/rubocop-hq/rubocop/pull/8474)
   * [`Lint/TrailingCommaInAttributeDeclaration`](https://github.com/rubocop-hq/rubocop/pull/8549)
 * Update [`Style/Alias` to prefer `alias_method`](https://github.com/testdouble/standard/pull/196)
+* Update rubocop-performance from 1.7.1 to 1.8.0:
+  * Plan to enable [`Performance/Sum`](https://github.com/rubocop-hq/rubocop-performance/pull/137) in the future, but there is currently a bug in the implementation
+* Add `ruby-2.3.yml` to add support for 2.3.
 
 ## 0.5.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.5.3
+
+* Update Rubocop from
+  [0.89.1](https://github.com/rubocop-hq/rubocop/releases/tag/v0.89.1)
+  to
+  [0.90](https://github.com/rubocop-hq/rubocop/releases/tag/v0.90.0),
+  enabling:
+  * [`Style/KeywordParametersOrder`](https://github.com/rubocop-hq/rubocop/pull/8563)
+  * [`Lint/DuplicateRequire`](https://github.com/rubocop-hq/rubocop/pull/8474)
+  * [`Lint/TrailingCommaInAttributeDeclaration`](https://github.com/rubocop-hq/rubocop/pull/8549)
+* Update [`Style/Alias` to prefer `alias_method`](https://github.com/testdouble/standard/pull/196)
+
 ## 0.5.2
 
 * Turned off `Lint/MissingSuper`, because it effectively bans a common idiom in
@@ -108,4 +120,3 @@
 ## 0.3.0
 
 * Update Standard to track Rubocop 0.82.0 ([commit](https://github.com/testdouble/standard/commit/d663ea62d519c659087ad606bfed031c6303ff20))
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     standard (0.5.2)
-      rubocop (~> 0.89.1)
+      rubocop (~> 0.90)
       rubocop-performance (~> 1.7.1)
 
 GEM
@@ -13,7 +13,7 @@ GEM
     docile (1.3.2)
     gimme (0.5.0)
     method_source (1.0.0)
-    minitest (5.14.1)
+    minitest (5.14.2)
     parallel (1.19.2)
     parser (2.7.1.4)
       ast (~> 2.4.1)
@@ -24,7 +24,7 @@ GEM
     rake (13.0.1)
     regexp_parser (1.7.1)
     rexml (3.2.4)
-    rubocop (0.89.1)
+    rubocop (0.90.0)
       parallel (~> 1.10)
       parser (>= 2.7.1.1)
       rainbow (>= 2.2.2, < 4.0)
@@ -38,7 +38,7 @@ GEM
     rubocop-performance (1.7.1)
       rubocop (>= 0.82.0)
     ruby-progressbar (1.10.1)
-    simplecov (0.18.5)
+    simplecov (0.19.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     standard (0.5.2)
       rubocop (~> 0.90)
-      rubocop-performance (~> 1.7.1)
+      rubocop-performance (~> 1.8.0)
 
 GEM
   remote: https://rubygems.org/
@@ -35,8 +35,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (0.3.0)
       parser (>= 2.7.1.4)
-    rubocop-performance (1.7.1)
-      rubocop (>= 0.82.0)
+    rubocop-performance (1.8.0)
+      rubocop (>= 0.87.0)
     ruby-progressbar (1.10.1)
     simplecov (0.19.0)
       docile (~> 1.1)

--- a/config/base.yml
+++ b/config/base.yml
@@ -599,6 +599,9 @@ Performance/BindCall:
 Performance/Caller:
   Enabled: true
 
+Performance/CollectionLiteralInLoop:
+  Enabled: false
+
 Performance/CompareWithBlock:
   Enabled: true
 
@@ -672,6 +675,9 @@ Performance/StartWith:
 
 Performance/StringReplacement:
   Enabled: true
+
+Performance/Sum:
+  Enabled: false
 
 Performance/UnfreezeString:
   Enabled: true

--- a/config/base.yml
+++ b/config/base.yml
@@ -350,10 +350,13 @@ Lint/DuplicateCaseCondition:
 Lint/DuplicateElsifCondition:
   Enabled: true
 
+Lint/DuplicateHashKey:
+  Enabled: true
+
 Lint/DuplicateMethods:
   Enabled: true
 
-Lint/DuplicateHashKey:
+Lint/DuplicateRequire:
   Enabled: true
 
 Lint/DuplicateRescueException:
@@ -530,6 +533,9 @@ Lint/Syntax:
   Enabled: true
 
 Lint/TopLevelReturnWithArgument:
+  Enabled: true
+
+Lint/TrailingCommaInAttributeDeclaration:
   Enabled: true
 
 Lint/UnderscorePrefixedVariableName:
@@ -850,6 +856,9 @@ Style/IfWithSemicolon:
 Style/InfiniteLoop:
   Enabled: true
   SafeAutoCorrect: true
+
+Style/KeywordParametersOrder:
+  Enabled: true
 
 Style/LambdaCall:
   Enabled: true

--- a/config/ruby-2.2.yml
+++ b/config/ruby-2.2.yml
@@ -1,7 +1,4 @@
-inherit_from: ./base.yml
-
-AllCops:
-  TargetRubyVersion: 2.4 # The oldest supported
+inherit_from: ./ruby-2.3.yml
 
 Layout:
   HeredocIndentation:

--- a/config/ruby-2.3.yml
+++ b/config/ruby-2.3.yml
@@ -1,0 +1,8 @@
+inherit_from: ./base.yml
+
+AllCops:
+  TargetRubyVersion: 2.4 # The oldest supported
+
+Performance:
+  Sum:
+    Enabled: false

--- a/lib/standard/creates_config_store/assigns_rubocop_yaml.rb
+++ b/lib/standard/creates_config_store/assigns_rubocop_yaml.rb
@@ -16,6 +16,8 @@ class Standard::CreatesConfigStore
         "ruby-1.9.yml"
       elsif desired_version < Gem::Version.new("2.3")
         "ruby-2.2.yml"
+      elsif desired_version < Gem::Version.new("2.4")
+        "ruby-2.3.yml"
       else
         "base.yml"
       end

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubocop", "~> 0.90"
-  spec.add_dependency "rubocop-performance", "~> 1.7.1"
+  spec.add_dependency "rubocop-performance", "~> 1.8.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.89.1"
+  spec.add_dependency "rubocop", "~> 0.90"
   spec.add_dependency "rubocop-performance", "~> 1.7.1"
 
   spec.add_development_dependency "bundler"

--- a/test/fixture/cli/autocorrectable-bad.rb
+++ b/test/fixture/cli/autocorrectable-bad.rb
@@ -13,7 +13,12 @@ THINGS = {
     }
 
 class Something
+
+
+
     alias do_more_stuff do_stuff
+
+  attr_reader :foo,
 
     def do_stuff( a,b,c )
 	maths_and_stuff = 4 +
@@ -74,4 +79,12 @@ class AlignyStuff
     )
   end
 
+end
+
+def bad_function(test: true, a:, b:)
+  if test
+    a
+  else
+    b
+  end
 end

--- a/test/fixture/cli/autocorrectable-good.rb
+++ b/test/fixture/cli/autocorrectable-good.rb
@@ -15,6 +15,7 @@ THINGS = {
 class Something
   alias_method :do_more_stuff, :do_stuff
 
+  attr_reader :foo
   def do_stuff(a, b, c)
     maths_and_stuff = 4 +
       5 +
@@ -70,5 +71,13 @@ class AlignyStuff
       aws_secret_access_key: ENV["S3_SECRET"],
       region: ENV["S3_REGION"]
     )
+  end
+end
+
+def bad_function(a:, b:, test: true)
+  if test
+    a
+  else
+    b
   end
 end

--- a/test/standard/runners/rubocop_test.rb
+++ b/test/standard/runners/rubocop_test.rb
@@ -56,7 +56,7 @@ class Standard::Runners::RubocopTest < UnitTest
       C:  1:  8: [Corrected] Style/Semicolon: Do not use semicolons to terminate expressions.
       C:  1:  9: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
 
-      1 file inspected, 6 offenses detected, 4 offenses corrected
+      1 file inspected, 6 offenses detected, 4 offenses corrected, 1 more offense can be corrected with `rubocop -A`
       ====================
       def Foo
         'hi'


### PR DESCRIPTION
Updated to [rubocop 0.90](https://github.com/rubocop-hq/rubocop/releases/tag/v0.90.0) and enabled the following cops:

- [Style/KeywordParametersOrder](https://github.com/rubocop-hq/rubocop/pull/8563)
- [Lint/DuplicateRequire](https://github.com/rubocop-hq/rubocop/pull/8474)
- [Lint/TrailingCommaInAttributeDeclaration](https://github.com/rubocop-hq/rubocop/pull/8549)

