### PR TITLE
Remove `Performance/Sum`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased
+
+* Disable `Performance/Sum` because #208 and the lack of actual auto-correcting is also causing more trouble
+
 ## 0.7
 
 * Update rubocop from 0.91.1 to

--- a/config/base.yml
+++ b/config/base.yml
@@ -701,10 +701,6 @@ Performance/StartWith:
 Performance/StringReplacement:
   Enabled: true
 
-Performance/Sum:
-  Enabled: true
-  AutoCorrect: true
-
 Performance/UnfreezeString:
   Enabled: true
 

--- a/config/ruby-2.3.yml
+++ b/config/ruby-2.3.yml
@@ -2,7 +2,3 @@ inherit_from: ./base.yml
 
 AllCops:
   TargetRubyVersion: 2.4 # The oldest supported
-
-Performance:
-  Sum:
-    Enabled: false

--- a/test/fixture/cli/autocorrectable-bad.rb
+++ b/test/fixture/cli/autocorrectable-bad.rb
@@ -46,9 +46,7 @@ class Something
           32 + 3
         end
         THINGS.keys.each { |key|
-            if ( (5..10).reduce(10,:+) > 1 )
-                THINGS[key] = plus_stuff[i]
-            end
+            THINGS[key] = plus_stuff[i]
         }
     end
 

--- a/test/fixture/cli/autocorrectable-good.rb
+++ b/test/fixture/cli/autocorrectable-good.rb
@@ -42,9 +42,7 @@ class Something
       32 + 3
     end
     THINGS.keys.each do |key|
-      if (5..10).sum(10) > 1
-        THINGS[key] = plus_stuff[i]
-      end
+      THINGS[key] = plus_stuff[i]
     end
   end
 


### PR DESCRIPTION
- Fixes #208
- The rule isn't [working as intentended](https://github.com/rubocop-hq/rubocop-performance/issues/171)