### PR TITLE
Change defaults for TrainingComma hash/array cops

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -1118,14 +1118,14 @@ Style/TrailingCommaInArguments:
 
 Style/TrailingCommaInArrayLiteral:
   Enabled: true
-  EnforcedStyleForMultiline: no_comma
+  EnforcedStyleForMultiline: comma
 
 Style/TrailingCommaInBlockArgs:
   Enabled: true
 
 Style/TrailingCommaInHashLiteral:
   Enabled: true
-  EnforcedStyleForMultiline: no_comma
+  EnforcedStyleForMultiline: comma
 
 Style/TrailingMethodEndStatement:
   Enabled: true


### PR DESCRIPTION
I think that defaults for Trailing Commas cops should be switched to `EnforcedStyleForMultiline: comma`. 

> It helps with consistency, preventing copy-paste errors, and maintaining attribution (minimizing impact on diffs).

Quoting from /r/javascript: https://www.reddit.com/r/javascript/comments/6vqsjh/whats_with_the_trailing_commas/

Here are examples from rubocop:
https://docs.rubocop.org/rubocop/1.0/cops_style.html#styletrailingcommainarrayliteral
https://docs.rubocop.org/rubocop/1.0/cops_style.html#enforcedstyleformultiline-comma-3