### PR TITLE
upgrade rubocop to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+* Update rubocop from 1.1.0 to [1.2.0](https://github.com/rubocop-hq/rubocop/releases/tag/v1.2.0)
 * Update rubocop from 1.0.0 to [1.1.0](https://github.com/rubocop-hq/rubocop/releases/tag/v1.1.0) enabling:
   * [`Lint/DuplicateRegexpCharacterClassElement`](https://github.com/rubocop-hq/rubocop/pull/8896)
   * [`Style/ArgumentsForwarding`](https://github.com/rubocop-hq/rubocop/pull/7646)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     standard (0.8.1)
-      rubocop (= 1.1.0)
+      rubocop (= 1.2.0)
       rubocop-performance (= 1.8.1)
 
 GEM
@@ -24,7 +24,7 @@ GEM
     rake (13.0.1)
     regexp_parser (1.8.2)
     rexml (3.2.4)
-    rubocop (1.1.0)
+    rubocop (1.2.0)
       parallel (~> 1.10)
       parser (>= 2.7.1.5)
       rainbow (>= 2.2.2, < 4.0)
@@ -33,7 +33,7 @@ GEM
       rubocop-ast (>= 1.0.1)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (1.1.0)
+    rubocop-ast (1.1.1)
       parser (>= 2.7.1.5)
     rubocop-performance (1.8.1)
       rubocop (>= 0.87.0)

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "1.1.0"
+  spec.add_dependency "rubocop", "1.2.0"
   spec.add_dependency "rubocop-performance", "1.8.1"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
I want to enable the collection compact cop, but it seems like it might be a bit buggy right now.