### PR TITLE
update to rubocop 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+* Update rubocop from 1.2.0 to [1.3.0](https://github.com/rubocop-hq/rubocop/releases/tag/v1.3.0) enabling:
+  * [`Style/NilLambda`](https://github.com/rubocop-hq/rubocop/pull/9020)
+  * [`Lint/DuplicateBranch`](https://github.com/rubocop-hq/rubocop/pull/8404)
+  
 ## 0.9.0
 
 * Update rubocop from 1.0.0 to [1.2.0](https://github.com/rubocop-hq/rubocop/releases/tag/v1.2.0) enabling:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     standard (0.9.0)
-      rubocop (= 1.2.0)
+      rubocop (= 1.3.0)
       rubocop-performance (= 1.8.1)
 
 GEM
@@ -14,7 +14,7 @@ GEM
     gimme (0.5.0)
     method_source (1.0.0)
     minitest (5.14.2)
-    parallel (1.19.2)
+    parallel (1.20.0)
     parser (2.7.2.0)
       ast (~> 2.4.1)
     pry (0.13.1)
@@ -24,13 +24,13 @@ GEM
     rake (13.0.1)
     regexp_parser (1.8.2)
     rexml (3.2.4)
-    rubocop (1.2.0)
+    rubocop (1.3.0)
       parallel (~> 1.10)
       parser (>= 2.7.1.5)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8)
       rexml
-      rubocop-ast (>= 1.0.1)
+      rubocop-ast (>= 1.1.1)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (1.1.1)

--- a/config/base.yml
+++ b/config/base.yml
@@ -360,6 +360,9 @@ Lint/DeprecatedClassMethods:
 Lint/DeprecatedOpenSSLConstant:
   Enabled: true
 
+Lint/DuplicateBranch:
+  Enabled: true
+
 Lint/DuplicateCaseCondition:
   Enabled: true
 
@@ -893,7 +896,6 @@ Style/IfWithSemicolon:
 
 Style/InfiniteLoop:
   Enabled: true
-  SafeAutoCorrect: true
 
 Style/KeywordParametersOrder:
   Enabled: true
@@ -970,6 +972,9 @@ Style/NestedTernaryOperator:
 Style/NilComparison:
   Enabled: true
   EnforcedStyle: predicate
+
+Style/NilLambda:
+  Enabled: true
 
 Style/NonNilCheck:
   Enabled: true

--- a/lib/standard/cop/semantic_blocks.rb
+++ b/lib/standard/cop/semantic_blocks.rb
@@ -28,9 +28,7 @@ module RuboCop::Cop
       def autocorrect(node)
         return if correction_would_break_code?(node)
 
-        if node.single_line?
-          replace_do_end_with_braces(node.loc)
-        elsif node.braces?
+        if node.braces?
           replace_braces_with_do_end(node.loc)
         else
           replace_do_end_with_braces(node.loc)

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "1.2.0"
+  spec.add_dependency "rubocop", "1.3.0"
   spec.add_dependency "rubocop-performance", "1.8.1"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
Update rubocop from 1.2.0 to [1.3.0](https://github.com/rubocop-hq/rubocop/releases/tag/v1.3.0) enabling:
  * [`Style/NilLambda`](https://github.com/rubocop-hq/rubocop/pull/9020)
  * [`Lint/DuplicateBranch`](https://github.com/rubocop-hq/rubocop/pull/8404)
  
