### PR TITLE
Sort config YAML entries by key

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -173,6 +173,10 @@ Layout/IndentationConsistency:
   Enabled: true
   EnforcedStyle: normal
 
+Layout/IndentationStyle:
+  Enabled: true
+  IndentationWidth: ~
+
 Layout/IndentationWidth:
   Enabled: true
   Width: 2
@@ -181,10 +185,10 @@ Layout/IndentationWidth:
 Layout/InitialIndentation:
   Enabled: true
 
-Layout/LeadingEmptyLines:
+Layout/LeadingCommentSpace:
   Enabled: true
 
-Layout/LeadingCommentSpace:
+Layout/LeadingEmptyLines:
   Enabled: true
 
 Layout/MultilineArrayBraceLayout:
@@ -250,6 +254,9 @@ Layout/SpaceAroundEqualsInParameterDefault:
 Layout/SpaceAroundKeyword:
   Enabled: true
 
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
 Layout/SpaceAroundOperators:
   Enabled: true
   AllowForAlignment: true
@@ -313,10 +320,6 @@ Layout/SpaceInsideReferenceBrackets:
 Layout/SpaceInsideStringInterpolation:
   Enabled: true
   EnforcedStyle: no_space
-
-Layout/IndentationStyle:
-  Enabled: true
-  IndentationWidth: ~
 
 Layout/TrailingEmptyLines:
   Enabled: true
@@ -551,9 +554,6 @@ Lint/ShadowedArgument:
 Lint/ShadowedException:
   Enabled: true
 
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
-
 Lint/Syntax:
   Enabled: true
 
@@ -600,6 +600,13 @@ Migration/DepartmentName:
 Naming/BinaryOperatorParameterName:
   Enabled: true
 
+Naming/BlockParameterName:
+  Enabled: true
+  MinNameLength: 1
+  AllowNamesEndingInNumbers: true
+  AllowedNames: []
+  ForbiddenNames: []
+
 Naming/ClassAndModuleCamelCase:
   Enabled: true
 
@@ -609,13 +616,6 @@ Naming/ConstantName:
 Naming/HeredocDelimiterCase:
   Enabled: true
   EnforcedStyle: uppercase
-
-Naming/BlockParameterName:
-  Enabled: true
-  MinNameLength: 1
-  AllowNamesEndingInNumbers: true
-  AllowedNames: []
-  ForbiddenNames: []
 
 Naming/VariableName:
   Enabled: true
@@ -1022,6 +1022,9 @@ Style/RedundantAssignment:
 Style/RedundantBegin:
   Enabled: true
 
+Style/RedundantCondition:
+  Enabled: true
+
 Style/RedundantConditional:
   Enabled: true
 
@@ -1037,7 +1040,13 @@ Style/RedundantFileExtensionInRequire:
 Style/RedundantFreeze:
   Enabled: true
 
+Style/RedundantInterpolation:
+  Enabled: true
+
 Style/RedundantParentheses:
+  Enabled: true
+
+Style/RedundantPercentQ:
   Enabled: true
 
 Style/RedundantRegexpCharacterClass:
@@ -1051,6 +1060,9 @@ Style/RedundantReturn:
   AllowMultipleReturnValues: false
 
 Style/RedundantSelf:
+  Enabled: true
+
+Style/RedundantSort:
   Enabled: true
 
 Style/RedundantSortBy:
@@ -1167,18 +1179,6 @@ Style/TrivialAccessors:
     - to_sym
 
 Style/UnlessElse:
-  Enabled: true
-
-Style/RedundantCondition:
-  Enabled: true
-
-Style/RedundantInterpolation:
-  Enabled: true
-
-Style/RedundantPercentQ:
-  Enabled: true
-
-Style/RedundantSort:
   Enabled: true
 
 Style/UnpackFirst:

--- a/config/base.yml
+++ b/config/base.yml
@@ -56,10 +56,10 @@ Layout/BlockAlignment:
 Layout/BlockEndNewline:
   Enabled: true
 
-# Disabled because IndentOneStep can't be configured for one-liner cases. See:
-# https://github.com/rubocop-hq/rubocop/issues/6447
-# Layout/CaseIndentation:
-  # Enabled: true
+Layout/CaseIndentation:
+  # Disabled because IndentOneStep can't be configured for one-liner cases. See:
+  # https://github.com/rubocop-hq/rubocop/issues/6447
+  Enabled: false
 
 Layout/ClosingHeredocIndentation:
   Enabled: true
@@ -728,7 +728,6 @@ Security/Open:
 Security/YAMLLoad:
   Enabled: true
   SafeAutoCorrect: false
-
 
 Standard/SemanticBlocks:
   ProceduralMethods:

--- a/config/ruby-1.8.yml
+++ b/config/ruby-1.8.yml
@@ -1,8 +1,7 @@
 inherit_from: ./ruby-1.9.yml
 
-Style/Lambda:
-  Enabled: false
-
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
 
+Style/Lambda:
+  Enabled: false


### PR DESCRIPTION
I found that the cops in config/base.yml are random ordered (or "almost sorted"), but it's easier to read for humans if the cops are sorted.

Here's a very roughly written sorting script, and the result is PRed.

```ruby
yml = File.read 'config/base.yml'

yml =~ /(.*)(AllCops:.*)/m
header, cops = $1, $2

sorted = cops.split("\n\n").sort_by { |cop| cop.lines.first }.join("\n\n")

File.write 'config/base.yml', header + sorted
```