### PR TITLE
Update rubocop to 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@
 * Update rubocop from 1.2.0 to [1.3.0](https://github.com/rubocop-hq/rubocop/releases/tag/v1.3.0) enabling:
   * [`Style/NilLambda`](https://github.com/rubocop-hq/rubocop/pull/9020)
   * [`Lint/DuplicateBranch`](https://github.com/rubocop-hq/rubocop/pull/8404)
-  
+
+* Update rubocop from 1.3.0 to [1.4.2](https://github.com/rubocop-hq/rubocop/releases/tag/v1.4.2) enabling:
+  * [`Style/RedundantArgument`](https://github.com/rubocop-hq/rubocop/pull/9077)
+  * Autocorrect for [`Layout/LineLength`](https://github.com/rubocop-hq/rubocop/issues/9073)
+
 ## 0.9.0
 
 * Update rubocop from 1.0.0 to [1.2.0](https://github.com/rubocop-hq/rubocop/releases/tag/v1.2.0) enabling:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     standard (0.9.0)
-      rubocop (= 1.3.0)
+      rubocop (= 1.4.2)
       rubocop-performance (= 1.8.1)
 
 GEM
@@ -14,7 +14,7 @@ GEM
     gimme (0.5.0)
     method_source (1.0.0)
     minitest (5.14.2)
-    parallel (1.20.0)
+    parallel (1.20.1)
     parser (2.7.2.0)
       ast (~> 2.4.1)
     pry (0.13.1)
@@ -22,9 +22,9 @@ GEM
       method_source (~> 1.0)
     rainbow (3.0.0)
     rake (13.0.1)
-    regexp_parser (1.8.2)
+    regexp_parser (2.0.0)
     rexml (3.2.4)
-    rubocop (1.3.0)
+    rubocop (1.4.2)
       parallel (~> 1.10)
       parser (>= 2.7.1.5)
       rainbow (>= 2.2.2, < 4.0)
@@ -33,7 +33,7 @@ GEM
       rubocop-ast (>= 1.1.1)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (1.1.1)
+    rubocop-ast (1.2.0)
       parser (>= 2.7.1.5)
     rubocop-performance (1.8.1)
       rubocop (>= 0.87.0)

--- a/config/base.yml
+++ b/config/base.yml
@@ -1016,6 +1016,9 @@ Style/Proc:
 Style/RandomWithOffset:
   Enabled: true
 
+Style/RedundantArgument:
+  Enabled: true
+
 Style/RedundantAssignment:
   Enabled: true
 

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "1.3.0"
+  spec.add_dependency "rubocop", "1.4.2"
   spec.add_dependency "rubocop-performance", "1.8.1"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
Update rubocop from 1.3.0 to [1.4.2](https://github.com/rubocop-hq/rubocop/releases/tag/v1.4.2) enabling:

* [`Style/RedundantArgument`](https://github.com/rubocop-hq/rubocop/pull/9077)
* Autocorrect for [`Layout/LineLength`](https://github.com/rubocop-hq/rubocop/issues/9073)