### PR TITLE
updates to rubocop 1.4.2 and rubocop-performance 1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## unreleased
 
-* Update rubocop from 1.2.0 to [1.3.0](https://github.com/rubocop-hq/rubocop/releases/tag/v1.3.0) enabling:
+* Update rubocop-performance from 1.8.1 to [1.9.1](https://github.com/rubocop-hq/rubocop-performance/releases/tag/v1.9.1) enabling:
+  * [`Performance/BlockGivenWithExplicitBlock`](https://github.com/rubocop-hq/rubocop-performance/pull/173)
+  * [`Performance/ConstantRegexp`](https://github.com/rubocop-hq/rubocop-performance/pull/174)
+  * [`Performance/ArraySemiInfiniteRangeSlice`](https://github.com/rubocop-hq/rubocop-performance/pull/175)
+* Update rubocop from 1.2.0 to [1.4.2](https://github.com/rubocop-hq/rubocop/releases/tag/v1.4.2) enabling:
   * [`Style/NilLambda`](https://github.com/rubocop-hq/rubocop/pull/9020)
   * [`Lint/DuplicateBranch`](https://github.com/rubocop-hq/rubocop/pull/8404)
   

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     standard (0.9.0)
-      rubocop (= 1.3.0)
-      rubocop-performance (= 1.8.1)
+      rubocop (= 1.4.2)
+      rubocop-performance (= 1.9.1)
 
 GEM
   remote: https://rubygems.org/
@@ -14,7 +14,7 @@ GEM
     gimme (0.5.0)
     method_source (1.0.0)
     minitest (5.14.2)
-    parallel (1.20.0)
+    parallel (1.20.1)
     parser (2.7.2.0)
       ast (~> 2.4.1)
     pry (0.13.1)
@@ -22,9 +22,9 @@ GEM
       method_source (~> 1.0)
     rainbow (3.0.0)
     rake (13.0.1)
-    regexp_parser (1.8.2)
+    regexp_parser (2.0.0)
     rexml (3.2.4)
-    rubocop (1.3.0)
+    rubocop (1.4.2)
       parallel (~> 1.10)
       parser (>= 2.7.1.5)
       rainbow (>= 2.2.2, < 4.0)
@@ -33,10 +33,10 @@ GEM
       rubocop-ast (>= 1.1.1)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (1.1.1)
+    rubocop-ast (1.2.0)
       parser (>= 2.7.1.5)
-    rubocop-performance (1.8.1)
-      rubocop (>= 0.87.0)
+    rubocop-performance (1.9.1)
+      rubocop (>= 0.90.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.10.1)
     simplecov (0.19.0)

--- a/config/base.yml
+++ b/config/base.yml
@@ -621,10 +621,16 @@ Naming/VariableName:
   Enabled: true
   EnforcedStyle: snake_case
 
+Performance/ArraySemiInfiniteRangeSlice:
+  Enabled: true
+
 Performance/BigDecimalWithNumericArgument:
   Enabled: true
 
 Performance/BindCall:
+  Enabled: true
+
+Performance/BlockGivenWithExplicitBlock:
   Enabled: true
 
 Performance/Caller:
@@ -634,6 +640,9 @@ Performance/CollectionLiteralInLoop:
   Enabled: false
 
 Performance/CompareWithBlock:
+  Enabled: true
+
+Performance/ConstantRegexp:
   Enabled: true
 
 Performance/Count:

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "1.3.0"
-  spec.add_dependency "rubocop-performance", "1.8.1"
+  spec.add_dependency "rubocop", "1.4.2"
+  spec.add_dependency "rubocop-performance", "1.9.1"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
Lots of updates over the holidays! There are three new performance rules that we are adding:

- Performance/BlockGivenWithExplicitBlock | https://github.com/rubocop-hq/rubocop-performance/pull/173
- Performance/ConstantRegexp | https://github.com/rubocop-hq/rubocop-performance/pull/174
- Performance/ArraySemiInfiniteRangeSlice | https://github.com/rubocop-hq/rubocop-performance/pull/175
