### PR TITLE
remove Performance/ArraySemiInfiniteRangeSlice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased
+
+* remove [`Performance/ArraySemiInfiniteRangeSlice`](https://github.com/testdouble/standard/pull/225#discussion_r532678908)
+
 ## 0.10.0
 
 * Update rubocop-performance from 1.8.1 to [1.9.1](https://github.com/rubocop-hq/rubocop-performance/releases/tag/v1.9.1) enabling:

--- a/config/base.yml
+++ b/config/base.yml
@@ -621,9 +621,6 @@ Naming/VariableName:
   Enabled: true
   EnforcedStyle: snake_case
 
-Performance/ArraySemiInfiniteRangeSlice:
-  Enabled: true
-
 Performance/BigDecimalWithNumericArgument:
   Enabled: true
 


### PR DESCRIPTION
Apparently, this cop was added but is going to be removed soon https://github.com/rubocop-hq/rubocop-performance/issues/198