### PR TITLE
Proposal: disable Lint/DuplicateBranch

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -363,8 +363,9 @@ Lint/DeprecatedClassMethods:
 Lint/DeprecatedOpenSSLConstant:
   Enabled: true
 
+# Disabled because it can promote code that is overly DRY at the expense of readability -- see #TODO
 Lint/DuplicateBranch:
-  Enabled: true
+  Enabled: false
 
 Lint/DuplicateCaseCondition:
   Enabled: true

--- a/config/base.yml
+++ b/config/base.yml
@@ -363,7 +363,7 @@ Lint/DeprecatedClassMethods:
 Lint/DeprecatedOpenSSLConstant:
   Enabled: true
 
-# Disabled because it can promote code that is overly DRY at the expense of readability -- see #TODO
+# Disabled because it can promote code that is overly DRY at the expense of readability -- see https://github.com/testdouble/standard/pull/228
 Lint/DuplicateBranch:
   Enabled: false
 


### PR DESCRIPTION
This cop just started hollering for us. I think this is a step back for a pretty common usage of case statements w/ enums. Here is an example from a code base I work in everyday:

```
  def opd_load_for_facility_size
    case facility_size
    when "community" then 450
    when "small" then 1800
    when "medium" then 3000
    when "large" then 7500
    else 450
    end
  end
```

In our domain the four types of facility sizes are a well know attribute on our Facility model. So when getting something like this opd_load attribute for a Facility, having the value explicitly returned for each size makes sense, even tho community is duplicated with the else clause. The else clause is handling some legacy cases for facility size (I believe, it predates me joining Simple.org) where we could have a nil size or perhaps just old, bad values.

So while the refactoring Rubocop is proposing is more DRY in the technical sense, the logic here is not duplicated. Refactoring to handle the 450 case entirely in the else clause is a step backwards in terms of our readability in our codebase. To take a cue from Sandi Metz, this rule pushes us towards the wrong abstract - Facilities with size community are not the same thing as the legacy facilities that are captured by the else clause here.

While I can see cases where you may want this cop enabled, I think this an overly strict definition of correctness that isn't in the spirit of standardrb. This is also way more than I've written about a single lint rule, so maybe I should just figure out how to turn off the rule for our project and move on 😏 .

But I think this should be off for the default looser world of standardrb - what say y'all?