### PR TITLE
Use `Cop::Base` API instead of legacy API

### DIFF
--- a/test/cop_invoker.rb
+++ b/test/cop_invoker.rb
@@ -25,9 +25,9 @@ module CopInvoker
 
     raise "Error parsing example code" unless @last_source.valid_syntax?
 
-    _investigate(cop, @last_source)
+    offenses = _investigate(cop, @last_source)
 
-    actual_annotations = expected.with_offense_annotations(cop.offenses)
+    actual_annotations = expected.with_offense_annotations(offenses)
     assert_equal expected.to_s, actual_annotations.to_s
   end
 
@@ -86,9 +86,9 @@ module CopInvoker
 
     raise "Error parsing example code" unless processed_source.valid_syntax?
 
-    _investigate(cop, processed_source)
+    offenses = _investigate(cop, processed_source)
 
-    assert_equal [], cop.offenses
+    assert_equal [], offenses
   end
 
   # Parsed representation of code annotated with the `^^^ Message` style

--- a/test/fixture/runner/bad_cop.rb
+++ b/test/fixture/runner/bad_cop.rb
@@ -1,15 +1,13 @@
 module RuboCop::Cop
   module Standard
-    class BadCop < RuboCop::Cop::Cop
+    class BadCop < RuboCop::Cop::Base
       include RuboCop::Cop::IgnoredMethods
+      extend RuboCop::Cop::AutoCorrector
 
       def on_send(node)
       end
 
       def on_block(node)
-      end
-
-      def autocorrect(node)
       end
     end
   end


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/7868.

This PR uses `Cop::Base` API instead of legacy `Cop::Cop` API.

`Cop::Cop` legacy API will be removed in RuboCop 2.0.

> if you maintain any RuboCop extensions, as the legacy API will be
> removed in RuboCop 2.0.

https://metaredux.com/posts/2020/10/21/rubocop-1-0.html