### PR TITLE
Update to 1.8.1 and enable Style/SlicingWithRange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## unreleased
+
+* Update rubocop from 1.7.0 to [1.8.1](https://github.com/rubocop-hq/rubocop/releases/tag/v1.8.1)
+* Enabled [`Style/SlicingWithRange`](https://github.com/testdouble/standard/issues/175)
+
 ## 0.11.0 
 
 * Update rubocop-performance from 1.9.1 to [1.9.2](https://github.com/rubocop-hq/rubocop-performance/releases/tag/v1.9.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     standard (0.11.0)
-      rubocop (= 1.7.0)
+      rubocop (= 1.8.1)
       rubocop-performance (= 1.9.2)
 
 GEM
@@ -24,15 +24,15 @@ GEM
     rake (13.0.3)
     regexp_parser (2.0.3)
     rexml (3.2.4)
-    rubocop (1.7.0)
+    rubocop (1.8.1)
       parallel (~> 1.10)
-      parser (>= 2.7.1.5)
+      parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml
       rubocop-ast (>= 1.2.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 2.0)
+      unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.4.0)
       parser (>= 2.7.1.5)
     rubocop-performance (1.9.2)
@@ -45,7 +45,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.2)
-    unicode-display_width (1.7.0)
+    unicode-display_width (2.0.0)
 
 PLATFORMS
   ruby

--- a/config/base.yml
+++ b/config/base.yml
@@ -1102,6 +1102,9 @@ Style/SingleLineMethods:
   Enabled: true
   AllowIfMethodIsEmpty: false
 
+Style/SlicingWithRange:
+  Enabled: true
+
 Style/StabbyLambdaParentheses:
   Enabled: true
   EnforcedStyle: require_parentheses

--- a/config/ruby-2.3.yml
+++ b/config/ruby-2.3.yml
@@ -1,4 +1,4 @@
-inherit_from: ./base.yml
+inherit_from: ./ruby-2.5.yml
 
 AllCops:
   TargetRubyVersion: 2.4 # The oldest supported

--- a/config/ruby-2.5.yml
+++ b/config/ruby-2.5.yml
@@ -1,0 +1,7 @@
+inherit_from: ./base.yml
+
+AllCops:
+  TargetRubyVersion: 2.5
+
+Style/SlicingWithRange:
+  Enabled: false

--- a/lib/standard/creates_config_store/assigns_rubocop_yaml.rb
+++ b/lib/standard/creates_config_store/assigns_rubocop_yaml.rb
@@ -18,6 +18,8 @@ class Standard::CreatesConfigStore
         "ruby-2.2.yml"
       elsif desired_version < Gem::Version.new("2.4")
         "ruby-2.3.yml"
+      elsif desired_version < Gem::Version.new("2.6")
+        "ruby-2.5.yml"
       else
         "base.yml"
       end

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "1.7.0"
+  spec.add_dependency "rubocop", "1.8.1"
   spec.add_dependency "rubocop-performance", "1.9.2"
 end

--- a/test/standard/runners/rubocop_test.rb
+++ b/test/standard/runners/rubocop_test.rb
@@ -49,18 +49,14 @@ class Standard::Runners::RubocopTest < UnitTest
 
     expected_out = <<-OUT.gsub(/^ {6}/, "")
       == test/fixture/runner/agreeable.rb ==
-      C:  1:  1: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
       C:  1:  1: [Corrected] Style/SingleLineMethods: Avoid single-line method definitions.
-      C:  1:  5: Naming/MethodName: Use snake_case for method names.
       C:  1:  8: [Corrected] Layout/SpaceAfterSemicolon: Space missing after semicolon.
-      C:  1:  8: [Corrected] Style/Semicolon: Do not use semicolons to terminate expressions.
-      C:  1:  9: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
+      E:  1: 11: Lint/Syntax: unexpected token tEQL
+      (Using Ruby 2.4 parser; configure using TargetRubyVersion parameter, under AllCops)
 
-      1 file inspected, 6 offenses detected, 4 offenses corrected, 1 more offense can be corrected with `rubocop -A`
+      1 file inspected, 3 offenses detected, 2 offenses corrected
       ====================
-      def Foo
-        'hi'
-      end
+      def Foo() = 'hi'
     OUT
     assert_equal expected_out, fake_out.string
     assert_equal "", fake_err.string


### PR DESCRIPTION
Fixes #175

Note: looks like Rubocop changed their defaults, so that's why all the changes in `test/standard/runners/rubocop_test.rb`