### PR TITLE
Add support for --stderr

### DIFF
--- a/lib/standard/runners/rubocop.rb
+++ b/lib/standard/runners/rubocop.rb
@@ -28,7 +28,11 @@ module Standard
       def print_corrected_code_if_fixing_stdin(rubocop_options)
         return unless rubocop_options[:stdin] && rubocop_options[:auto_correct]
 
-        puts "=" * 20
+        if rubocop_options[:stderr]
+          warn "=" * 20
+        else
+          puts "=" * 20
+        end
         print rubocop_options[:stdin]
       end
     end


### PR DESCRIPTION
cf. https://github.com/rubocop-hq/rubocop/pull/9043

I tried to add a test for this, but I couldn't because the implementation in Rubocop alters `$stdout`/`$stderr` and that conflicts with `do_with_fake_io`.