### PR TITLE
Use RuboCop::CLI::Command::ExecuteRunner

### DIFF
--- a/lib/standard/cli.rb
+++ b/lib/standard/cli.rb
@@ -3,9 +3,6 @@ require_relative "loads_runner"
 
 module Standard
   class Cli
-    SUCCESS_STATUS_CODE = 0
-    FAILURE_STATUS_CODE = 1
-
     def initialize(argv)
       @argv = argv
       @builds_config = BuildsConfig.new
@@ -14,10 +11,7 @@ module Standard
 
     def run
       config = @builds_config.call(@argv)
-
-      success = @loads_runner.call(config.runner).call(config)
-
-      success ? SUCCESS_STATUS_CODE : FAILURE_STATUS_CODE
+      @loads_runner.call(config.runner).call(config)
     end
   end
 end

--- a/lib/standard/runners/genignore.rb
+++ b/lib/standard/runners/genignore.rb
@@ -13,7 +13,7 @@ module Standard
           config.rubocop_options[:formatters] = [["files", temp_file.path]]
           config.rubocop_options[:format] = "files"
           config.rubocop_options[:out] = temp_file.path
-          Runners::Rubocop.new.call(config)
+          exit_code = Runners::Rubocop.new.call(config)
 
           # Read in the files with errors.  It will have the absolute paths
           # of the files but we only want the relative path.
@@ -37,6 +37,7 @@ module Standard
             file.puts "# Remove from this list as you refactor files."
             file.write(yaml_format_errors.to_yaml)
           end
+          exit_code
         ensure
           # Clean up temp file.
           temp_file.close

--- a/lib/standard/runners/rubocop.rb
+++ b/lib/standard/runners/rubocop.rb
@@ -4,36 +4,15 @@ module Standard
   module Runners
     class Rubocop
       def call(config)
-        rubocop_runner = RuboCop::Runner.new(
-          config.rubocop_options,
-          config.rubocop_config_store
+        rubocop_runner = RuboCop::CLI::Command::ExecuteRunner.new(
+          RuboCop::CLI::Environment.new(
+            config.rubocop_options,
+            config.rubocop_config_store,
+            config.paths
+          )
         )
 
-        rubocop_runner.run(config.paths).tap do |success|
-          print_errors_and_warnings(success, rubocop_runner)
-          print_corrected_code_if_fixing_stdin(config.rubocop_options)
-        end
-      end
-
-      private
-
-      def print_errors_and_warnings(success, rubocop_runner)
-        return unless success
-
-        (rubocop_runner.warnings + rubocop_runner.errors).each do |message|
-          warn message
-        end
-      end
-
-      def print_corrected_code_if_fixing_stdin(rubocop_options)
-        return unless rubocop_options[:stdin] && rubocop_options[:auto_correct]
-
-        if rubocop_options[:stderr]
-          warn "=" * 20
-        else
-          puts "=" * 20
-        end
-        print rubocop_options[:stdin]
+        rubocop_runner.run
       end
     end
   end

--- a/test/standard/runners/rubocop_test.rb
+++ b/test/standard/runners/rubocop_test.rb
@@ -47,7 +47,7 @@ class Standard::Runners::RubocopTest < UnitTest
       ))
     }
 
-    expected_out = <<-OUT.gsub(/^ {6}/, "")
+    expected_out = <<~OUT
       == test/fixture/runner/agreeable.rb ==
       C:  1:  1: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
       C:  1:  1: [Corrected] Style/SingleLineMethods: Avoid single-line method definitions.
@@ -64,6 +64,37 @@ class Standard::Runners::RubocopTest < UnitTest
     OUT
     assert_equal expected_out, fake_out.string
     assert_equal "", fake_err.string
+  end
+
+  def test_print_corrected_output_on_stdin_with_corrections_on_stderr
+    fake_out, fake_err = do_with_fake_io {
+      @subject.call(create_config(
+        auto_correct: true,
+        safe_auto_correct: true,
+        stderr: true,
+        stdin: "def Foo;'hi'end\n"
+      ))
+    }
+
+    expected_out = <<~OUT
+      def Foo
+        'hi'
+      end
+    OUT
+    expected_err = <<~ERR
+      == test/fixture/runner/agreeable.rb ==
+      C:  1:  1: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
+      C:  1:  1: [Corrected] Style/SingleLineMethods: Avoid single-line method definitions.
+      C:  1:  5: Naming/MethodName: Use snake_case for method names.
+      C:  1:  8: [Corrected] Layout/SpaceAfterSemicolon: Space missing after semicolon.
+      C:  1:  8: [Corrected] Style/Semicolon: Do not use semicolons to terminate expressions.
+      C:  1:  9: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
+
+      1 file inspected, 6 offenses detected, 4 offenses corrected, 1 more offense can be corrected with `rubocop -A`
+      ====================
+    ERR
+    assert_equal expected_out, fake_out.string
+    assert_equal expected_err, fake_err.string
   end
 
   private


### PR DESCRIPTION
Preserves RuboCop exit status while using RuboCop logic for printing summary, either on stdout or stderr with `--stdin ... --stderr` options.

I ran into this issue while running a command like `cat file.rb | standardrb --no-color --stderr --fix --stdin file.rb`. I want the reformatted code on stdout with the warnings and summary on stderr. I don't know if the use of `Rubocop::Runner` was intentional, but using the execute runner works for my case.