### PR TITLE
Fix exit code for version and help runners

### DIFF
--- a/lib/standard/cli.rb
+++ b/lib/standard/cli.rb
@@ -11,7 +11,7 @@ module Standard
 
     def run
       config = @builds_config.call(@argv)
-      @loads_runner.call(config.runner).call(config)
+      @loads_runner.call(config.runner).call(config).to_i
     end
   end
 end

--- a/test/standard/cli_test.rb
+++ b/test/standard/cli_test.rb
@@ -36,4 +36,24 @@ class Standard::CliTest < UnitTest
     assert_empty fake_err.string
     assert_empty fake_out.string
   end
+
+  def test_version
+    fake_out, fake_err, exit_code = do_with_fake_io {
+      Standard::Cli.new(["--version"]).run
+    }
+
+    assert_equal 0, exit_code
+    assert_empty fake_err.string
+    refute_empty fake_out.string
+  end
+
+  def test_help
+    fake_out, fake_err, exit_code = do_with_fake_io {
+      Standard::Cli.new(["--help"]).run
+    }
+
+    assert_equal 0, exit_code
+    assert_empty fake_err.string
+    refute_empty fake_out.string
+  end
 end


### PR DESCRIPTION
Cast the runner's return value to `Integer` so we're going to be calling `exit` with an Integer. The original implementation had a ternary with explicit constants for the two exit codes. I could probably do something similar if the simple cast is insufficient.

Fixes this:

```
$ standardrb --help
... bunch of help output
TypeError: no implicit conversion from nil to integer
  /workspace/exe/standardrb:7:in `exit'
  /workspace/exe/standardrb:7:in `<top (required)>'
  /usr/local/bundle/bin/standardrb:23:in `load'
  /usr/local/bundle/bin/standardrb:23:in `<top (required)>'
```

```
$ standardrb --version
1.0.2
TypeError: no implicit conversion from nil to integer
  /workspace/exe/standardrb:7:in `exit'
  /workspace/exe/standardrb:7:in `<top (required)>'
  /usr/local/bundle/bin/standardrb:23:in `load'
  /usr/local/bundle/bin/standardrb:23:in `<top (required)>'
```