### PR TITLE
Updates GitHub test action to use native gem cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        ruby-version: [2.5, 2.6, 2.7, 3.0]
+        ruby-version: [2.5, 2.7, 3.0]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        ruby-version: [2.5, 2.7, 3.0]
+        ruby-version: [2.5, 2.6, 2.7, 3.0]
 
     runs-on: ${{ matrix.os }}
 
@@ -22,16 +22,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
-    - name: Set up caching
-      uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: bundle-user-ruby-${{ matrix.os }}-${{matrix.ruby-version }}-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          bundle-use-ruby-${{ matrix.os }}-${{ matrix.ruby-version }}-
-    - name: Install dependencies
-      run: |
-        bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
+        bundler-cache: true
     - name: Run tests for Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}
-      run: bundle exec rake
+      run: bundle config unset deployment && bundle exec rake


### PR DESCRIPTION
[The setup-ruby action was updated to allow installing and caching gems](https://github.com/ruby/setup-ruby#caching-bundle-install-automatically).  Since I introduced the caching mechanism before, I figured I'd updated it.

While this is much cleaner now, there is a caveat: only the latest stable versions of Ruby seem to build clean.  I left some commits to document this (the alternative that worked was excluding a `Gemfile.lock`).  If you are ok with dropping support for older Ruby versions from the build, or ignoring the `Gemfile.lock` from source control, then I can cleanup the commits on this. Otherwise I can just close this for now and revisit another time 😂 