### PR TITLE
remove EnforcedStyle: always on Style/AndOr to prevent unsafe change

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -747,7 +747,6 @@ Style/Alias:
 
 Style/AndOr:
   Enabled: true
-  EnforcedStyle: always
 
 Style/ArgumentsForwarding:
   Enabled: true


### PR DESCRIPTION
Running `standardrb --fix` should only be making safe changes and `Style/AndOr` with `EnforcedStyle: always` is not safe. A common example is in controllers when you want to return early after a render or redirect

```
  redirect_to some_path and return
```

with `EnforcedStyle: always` it will autocorrect it to
```
  redirect_to some_path && return
```
which results in different behavior. 

I propose keeping the [default EnforcedStyle](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/AndOr) since it will still enforce using `&&` over `and` when you would want it to.