### PR TITLE
Update RuboCop to 1.12.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     standard (1.0.4)
-      rubocop (= 1.11.0)
+      rubocop (= 1.12.1)
       rubocop-performance (= 1.10.1)
 
 GEM
@@ -24,7 +24,7 @@ GEM
     rake (13.0.3)
     regexp_parser (2.1.1)
     rexml (3.2.4)
-    rubocop (1.11.0)
+    rubocop (1.12.1)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)

--- a/lib/standard/rubocop/ext.rb
+++ b/lib/standard/rubocop/ext.rb
@@ -6,9 +6,9 @@ module RuboCop
     end
   end
 
-  class CommentConfig
-    remove_const :COMMENT_DIRECTIVE_REGEXP
-    COMMENT_DIRECTIVE_REGEXP = Regexp.new(
+  class DirectiveComment
+    remove_const :DIRECTIVE_COMMENT_REGEXP
+    DIRECTIVE_COMMENT_REGEXP = Regexp.new(
       ('# (?:standard|rubocop) : ((?:disable|enable|todo))\b ' + COPS_PATTERN)
         .gsub(" ", '\s*')
     )

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "1.11.0"
+  spec.add_dependency "rubocop", "1.12.1"
   spec.add_dependency "rubocop-performance", "1.10.1"
 end


### PR DESCRIPTION
This PR updates RuboCop to 1.12.1.
https://github.com/rubocop-hq/rubocop/compare/v1.11.0...v1.12.1

It supports private API change from `RuboCop::DirectiveComment::DIRECTIVE_COMMENT_REGEXP` to `RuboCop::DirectiveComment::COMMENT_DIRECTIVE_REGEXP`.

- https://github.com/rubocop/rubocop/pull/9569/commits/7f1f75c106ccb6a958050dd1f1a3572311306070
- https://github.com/rubocop/rubocop/commit/04217101cf5284119fdf24a70d022b3a1bcb1b03

And `Style/StringChars` cop is added in RuboCop 1.12. It is up to maintainers to decide whether to enable it :-)
https://github.com/rubocop/rubocop/pull/9615