### PR TITLE
Update rubocop and rubocop-performance and finally add in some new cops

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        ruby-version: [2.4, 2.7, 3.0]
+        ruby-version: [2.5, 2.7, 3.0]
 
     runs-on: ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## unreleased
+
+* Update rubocop from 1.12.1 to [1.13.0](https://github.com/rubocop-hq/rubocop/releases/tag/v1.13.0)
+* Update rubocop-performance from 1.9.2 to [1.11.1](https://github.com/rubocop-hq/rubocop-performance/releases/tag/v1.11.1)
+* Enabled the following rules:
+  * [`Performance/RedundantSplitRegexpArgument`](https://github.com/rubocop/rubocop-performance/pull/190)
+  * [`Style/IfWithBooleanLiteralBranches`](https://github.com/rubocop-hq/rubocop/pull/9396)
+  * [`Lint/TripleQuotes`](https://github.com/rubocop-hq/rubocop/pull/9402)
+  * [`Lint/SymbolConversion`](https://github.com/rubocop/rubocop/pull/9362)
+  * [`Lint/OrAssignmentToConstant`](https://github.com/rubocop-hq/rubocop/pull/9363)
+  * [`Lint/NumberedParameterAssignment`](https://github.com/rubocop-hq/rubocop/pull/9326)
+  * [`Style/HashConversion`](https://github.com/rubocop-hq/rubocop/pull/9478)
+  * [`Gemspec/DateAssignment`](https://github.com/rubocop-hq/rubocop/pull/9496)
+  * [`Style/StringChars`](https://github.com/rubocop/rubocop/pull/9615)
+
 ## 1.0.5
 
 * Update rubocop from 1.11.0 to [1.12.1](https://github.com/rubocop-hq/rubocop/releases/tag/v1.12.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     standard (1.0.5)
-      rubocop (= 1.12.1)
-      rubocop-performance (= 1.10.1)
+      rubocop (= 1.13.0)
+      rubocop-performance (= 1.11.1)
 
 GEM
   remote: https://rubygems.org/
@@ -15,16 +15,16 @@ GEM
     method_source (1.0.0)
     minitest (5.14.4)
     parallel (1.20.1)
-    parser (3.0.1.0)
+    parser (3.0.1.1)
       ast (~> 2.4.1)
-    pry (0.14.0)
+    pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
     rainbow (3.0.0)
     rake (13.0.3)
     regexp_parser (2.1.1)
     rexml (3.2.5)
-    rubocop (1.12.1)
+    rubocop (1.13.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -33,10 +33,10 @@ GEM
       rubocop-ast (>= 1.2.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.4.1)
-      parser (>= 2.7.1.5)
-    rubocop-performance (1.10.1)
-      rubocop (>= 0.90.0, < 2.0)
+    rubocop-ast (1.5.0)
+      parser (>= 3.0.1.1)
+    rubocop-performance (1.11.1)
+      rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.11.0)
     simplecov (0.21.2)
@@ -44,7 +44,7 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
-    simplecov_json_formatter (0.1.2)
+    simplecov_json_formatter (0.1.3)
     unicode-display_width (2.0.0)
 
 PLATFORMS
@@ -61,4 +61,4 @@ DEPENDENCIES
   standard!
 
 BUNDLED WITH
-   2.2.3
+   2.2.6

--- a/config/base.yml
+++ b/config/base.yml
@@ -21,6 +21,9 @@ Bundler/InsecureProtocolSource:
     - '**/Gemfile'
     - '**/gems.rb'
 
+Gemspec/DateAssignment:
+  Enabled: true
+
 Gemspec/DuplicatedAssignment:
   Enabled: true
   Include:
@@ -478,6 +481,12 @@ Lint/NonDeterministicRequireOrder:
 Lint/NonLocalExitFromIterator:
   Enabled: true
 
+Lint/NumberedParameterAssignment:
+  Enabled: true
+
+Lint/OrAssignmentToConstant:
+  Enabled: true
+
 Lint/OrderedMagicComments:
   Enabled: true
 
@@ -557,6 +566,9 @@ Lint/ShadowedArgument:
 Lint/ShadowedException:
   Enabled: true
 
+Lint/SymbolConversion:
+  Enabled: true
+
 Lint/Syntax:
   Enabled: true
 
@@ -564,6 +576,9 @@ Lint/TopLevelReturnWithArgument:
   Enabled: true
 
 Lint/TrailingCommaInAttributeDeclaration:
+  Enabled: true
+
+Lint/TripleQuotes:
   Enabled: true
 
 Lint/UnderscorePrefixedVariableName:
@@ -687,6 +702,9 @@ Performance/RedundantMerge:
   MaxKeyValuePairs: 2
 
 Performance/RedundantSortBlock:
+  Enabled: true
+
+Performance/RedundantSplitRegexpArgument:
   Enabled: true
 
 Performance/RedundantStringChars:
@@ -854,6 +872,9 @@ Style/GlobalVars:
   Enabled: true
   AllowedVariables: []
 
+Style/HashConversion:
+  Enabled: true
+
 Style/HashExcept:
   Enabled: true
 
@@ -868,6 +889,9 @@ Style/IfInsideElse:
   Enabled: true
 
 Style/IfUnlessModifierOfIfUnless:
+  Enabled: true
+
+Style/IfWithBooleanLiteralBranches:
   Enabled: true
 
 Style/IfWithSemicolon:
@@ -1087,6 +1111,9 @@ Style/StabbyLambdaParentheses:
   EnforcedStyle: require_parentheses
 
 Style/StderrPuts:
+  Enabled: true
+
+Style/StringChars:
   Enabled: true
 
 Style/StringLiterals:

--- a/config/ruby-1.9.yml
+++ b/config/ruby-1.9.yml
@@ -2,3 +2,6 @@ inherit_from: ./ruby-2.2.yml
 
 Style/Encoding:
   Enabled: false
+
+Style/HashConversion:
+  Enabled: false

--- a/config/ruby-2.3.yml
+++ b/config/ruby-2.3.yml
@@ -1,4 +1,1 @@
-inherit_from: ./ruby-2.5.yml
-
-AllCops:
-  TargetRubyVersion: 2.4 # The oldest supported
+inherit_from: ./ruby-2.4.yml

--- a/config/ruby-2.4.yml
+++ b/config/ruby-2.4.yml
@@ -1,0 +1,4 @@
+inherit_from: ./ruby-2.5.yml
+
+AllCops:
+  TargetRubyVersion: 2.5 # The oldest supported

--- a/lib/standard/creates_config_store/assigns_rubocop_yaml.rb
+++ b/lib/standard/creates_config_store/assigns_rubocop_yaml.rb
@@ -18,6 +18,8 @@ class Standard::CreatesConfigStore
         "ruby-2.2.yml"
       elsif desired_version < Gem::Version.new("2.4")
         "ruby-2.3.yml"
+      elsif desired_version < Gem::Version.new("2.5")
+        "ruby-2.4.yml"
       elsif desired_version < Gem::Version.new("2.6")
         "ruby-2.5.yml"
       elsif desired_version < Gem::Version.new("3.0")

--- a/lib/standard/creates_config_store/sets_target_ruby_version.rb
+++ b/lib/standard/creates_config_store/sets_target_ruby_version.rb
@@ -9,7 +9,7 @@ class Standard::CreatesConfigStore
     private
 
     def max_rubocop_supported_version(desired_version)
-      rubocop_supported_version = Gem::Version.new("2.4")
+      rubocop_supported_version = Gem::Version.new("2.5")
       if desired_version < rubocop_supported_version
         rubocop_supported_version
       else

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.version = Standard::VERSION
   spec.authors = ["Justin Searls"]
   spec.email = ["searls@gmail.com"]
-  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_ruby_version = ">= 2.5.0"
 
   spec.summary = "Ruby Style Guide, with linter & automatic code fixer"
   spec.homepage = "https://github.com/testdouble/standard"
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "1.12.1"
-  spec.add_dependency "rubocop-performance", "1.10.1"
+  spec.add_dependency "rubocop", "1.13.0"
+  spec.add_dependency "rubocop-performance", "1.11.1"
 end

--- a/test/standard/builds_config_test.rb
+++ b/test/standard/builds_config_test.rb
@@ -124,8 +124,8 @@ class Standard::BuildsConfigTest < UnitTest
   def highest_compatible_yml_version
     non_latest_ruby = Dir["config/*.yml"]
       .map { |n| n.match(/ruby-(.*)\.yml/) }.compact
-      .map { |m| Gem::Version.new(m[1]) }.sort
-      .find { |v| Gem::Version.new(RUBY_VERSION) < v }
+      .map { |m| Gem::Version.new(m[1]) }.sort.reverse
+      .find { |v| Gem::Version.new(RUBY_VERSION) > v }
 
     if non_latest_ruby
       "config/ruby-#{non_latest_ruby}.yml"

--- a/test/standard/builds_config_test.rb
+++ b/test/standard/builds_config_test.rb
@@ -74,7 +74,7 @@ class Standard::BuildsConfigTest < UnitTest
 
     assert_equal DEFAULT_OPTIONS, result.rubocop_options
 
-    assert_equal config_store("test/fixture/config/w", "config/ruby-1.9.yml", 2.4), result.rubocop_config_store.for("").to_h
+    assert_equal config_store("test/fixture/config/w", "config/ruby-1.9.yml", 2.5), result.rubocop_config_store.for("").to_h
   end
 
   def test_specified_standard_yaml_overrides_local


### PR DESCRIPTION
* Update rubocop from 1.12.1 to [1.13.0](https://github.com/rubocop-hq/rubocop/releases/tag/v1.13.0)
* Update rubocop-performance from 1.9.2 to [1.11.1](https://github.com/rubocop-hq/rubocop-performance/releases/tag/v1.11.1)
* Enabled the following rules:
  * [`Performance/RedundantSplitRegexpArgument`](https://github.com/rubocop/rubocop-performance/pull/190)
  * [`Style/IfWithBooleanLiteralBranches`](https://github.com/rubocop-hq/rubocop/pull/9396)
  * [`Lint/TripleQuotes`](https://github.com/rubocop-hq/rubocop/pull/9402)
  * [`Lint/SymbolConversion`](https://github.com/rubocop/rubocop/pull/9362)
  * [`Lint/OrAssignmentToConstant`](https://github.com/rubocop-hq/rubocop/pull/9363)
  * [`Lint/NumberedParameterAssignment`](https://github.com/rubocop-hq/rubocop/pull/9326)
  * [`Style/HashConversion`](https://github.com/rubocop-hq/rubocop/pull/9478)
  * [`Gemspec/DateAssignment`](https://github.com/rubocop-hq/rubocop/pull/9496)
  * [`Style/StringChars`](https://github.com/rubocop/rubocop/pull/9615)