### PR TITLE
fix #292 and disable Performance/DeleteSuffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 
 * Workaround RuboCop's CLI from erroring when it detects a cop named
   BlockDelimiters by renaming it to BlockSingleLineBraces
-  ([#271](https://github.com/testdouble/standard/issues/271)0
+  ([#271](https://github.com/testdouble/standard/issues/271))
 
 ## 1.0.3
 

--- a/config/base.yml
+++ b/config/base.yml
@@ -667,7 +667,7 @@ Performance/DeletePrefix:
   Enabled: true
 
 Performance/DeleteSuffix:
-  Enabled: true
+  Enabled: false
 
 Performance/Detect:
   Enabled: true


### PR DESCRIPTION
This cop is not safe. I've opened up an issue in rubocop-performance, but in the meantime, we should disable this rule.