### PR TITLE
upgrade rubocop and rubocop-performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## unreleased
+
+* Update rubocop from 1.14.0 to [1.15.0](https://github.com/rubocop-hq/rubocop/releases/tag/v1.15.0)
+* Update rubocop-performance from 1.11.2 to [1.11.3](https://github.com/rubocop-hq/rubocop-performance/releases/tag/v1.11.3)
+
 ## 1.1.1
 
 * Update rubocop from 1.13.0 to [1.14.0](https://github.com/rubocop-hq/rubocop/releases/tag/v1.14.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     standard (1.1.1)
-      rubocop (= 1.14.0)
-      rubocop-performance (= 1.11.2)
+      rubocop (= 1.15.0)
+      rubocop-performance (= 1.11.3)
 
 GEM
   remote: https://rubygems.org/
@@ -24,7 +24,7 @@ GEM
     rake (13.0.3)
     regexp_parser (2.1.1)
     rexml (3.2.5)
-    rubocop (1.14.0)
+    rubocop (1.15.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -35,7 +35,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.5.0)
       parser (>= 3.0.1.1)
-    rubocop-performance (1.11.2)
+    rubocop-performance (1.11.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.11.0)

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "1.14.0"
-  spec.add_dependency "rubocop-performance", "1.11.2"
+  spec.add_dependency "rubocop", "1.15.0"
+  spec.add_dependency "rubocop-performance", "1.11.3"
 end


### PR DESCRIPTION
Was too quick initially. It looks like, with this upgrade, we are seeing the `Layout/HashAlignment` now look as though we are using `EnforcedColonStyle: table` instead of `key`. This is the diff of what it is correcting to to what it should be correcting to in our tests:

```
<     hi: "neat"
---
>   hi: "neat"
68,71c68,71
<     thing_1:           0,
<      thing_2:           1,
<      longer_thing:      2,
<      even_longer_thing: 3
---
>     thing_1: 0,
>     thing_2: 1,
>     longer_thing: 2,
>     even_longer_thing: 3
76,77c76,77
<       provider:              "AWS",
<       aws_access_key_id:     ENV["S3_ACCESS_KEY"],
---
>       provider: "AWS",
>       aws_access_key_id: ENV["S3_ACCESS_KEY"],
79c79
<       region:                ENV["S3_REGION"]
---
>       region: ENV["S3_REGION"]
83,84c83,84
<       provider:              "AWS",
<       aws_access_key_id:     ENV["S3_ACCESS_KEY"],
---
>       provider: "AWS",
>       aws_access_key_id: ENV["S3_ACCESS_KEY"],
86c86
<       region:                ENV["S3_REGION"]
---
>       region: ENV["S3_REGION"]
```