### PR TITLE
upgrade to 1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased
+
+* Update rubocop from 1.14.0 to [1.16.0](https://github.com/rubocop-hq/rubocop/releases/tag/v1.16.0)
+
 ## 1.1.1
 
 * Update rubocop from 1.13.0 to [1.14.0](https://github.com/rubocop-hq/rubocop/releases/tag/v1.14.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-* Update rubocop from 1.14.0 to [1.16.0](https://github.com/rubocop-hq/rubocop/releases/tag/v1.16.0)
+* Update rubocop from 1.14.0 to [1.17.0](https://github.com/rubocop-hq/rubocop/releases/tag/v1.17.0)
 
 ## 1.1.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     standard (1.1.1)
-      rubocop (= 1.14.0)
+      rubocop (= 1.16.0)
       rubocop-performance (= 1.11.2)
 
 GEM
@@ -24,16 +24,16 @@ GEM
     rake (13.0.3)
     regexp_parser (2.1.1)
     rexml (3.2.5)
-    rubocop (1.14.0)
+    rubocop (1.16.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 1.5.0, < 2.0)
+      rubocop-ast (>= 1.7.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.5.0)
+    rubocop-ast (1.7.0)
       parser (>= 3.0.1.1)
     rubocop-performance (1.11.2)
       rubocop (>= 1.7.0, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     standard (1.1.1)
-      rubocop (= 1.16.0)
+      rubocop (= 1.17.0)
       rubocop-performance (= 1.11.2)
 
 GEM
@@ -24,7 +24,7 @@ GEM
     rake (13.0.3)
     regexp_parser (2.1.1)
     rexml (3.2.5)
-    rubocop (1.16.0)
+    rubocop (1.17.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "1.14.0"
+  spec.add_dependency "rubocop", "1.16.0"
   spec.add_dependency "rubocop-performance", "1.11.2"
 end

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "1.16.0"
+  spec.add_dependency "rubocop", "1.17.0"
   spec.add_dependency "rubocop-performance", "1.11.2"
 end


### PR DESCRIPTION
Pffft looks like there is still an issue with the hash alignment
```
  1) Failure:
Standard::CliTest#test_autocorrectable [/Users/jennifer/dev/standard/test/standard/cli_test.rb:14]:
--- expected
+++ actual
@@ -162,13 +162,13 @@
 " +
 "    config.fog_credentials_as_kwargs(
 " +
-"      provider: \"AWS\",
+"      provider:              \"AWS\",
 " +
-"      aws_access_key_id: ENV[\"S3_ACCESS_KEY\"],
+"      aws_access_key_id:     ENV[\"S3_ACCESS_KEY\"],
 " +
 "      aws_secret_access_key: ENV[\"S3_SECRET\"],
 " +
-"      region: ENV[\"S3_REGION\"]
+"      region:                ENV[\"S3_REGION\"]
 " +
 "    )
 " +
 ```