### PR TITLE
Add the Danger plugin to the list of tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ from editor plugins:
 * [Pronto](https://github.com/julianrubisch/pronto-standardrb)
 * [Spring](https://github.com/lakim/spring-commands-standard)
 * [Guard](https://github.com/JodyVanden/guard-standardrb)
+* [Danger](https://github.com/ashfurrow/danger-rubocop/)
 
 ## Contributing
 


### PR DESCRIPTION
Since 0.9.5, you can [run Standard with Danger using danger-rubocop](https://github.com/ashfurrow/danger-rubocop/pull/51). I've added this to the list of tools in the README