### PR TITLE
Add '--generate-todo' to CLI help output

### DIFF
--- a/lib/standard/runners/help.rb
+++ b/lib/standard/runners/help.rb
@@ -12,6 +12,7 @@ module Standard
             --fix             Automatically fix failures where possible
             --no-fix          Do not automatically fix failures
             --format <name>   Format output with any RuboCop formatter (e.g. "json")
+            --generate-todo   Create a .standard_todo.yml that lists all the files that contain errors
             -v, --version     Print the version of Standard
             -h, --help        Print this message
             FILE              Files to lint [default: ./]

--- a/test/standard/runners/help_test.rb
+++ b/test/standard/runners/help_test.rb
@@ -20,6 +20,7 @@ class Standard::Runners::HelpTest < UnitTest
         --fix             Automatically fix failures where possible
         --no-fix          Do not automatically fix failures
         --format <name>   Format output with any RuboCop formatter (e.g. "json")
+        --generate-todo   Create a .standard_todo.yml that lists all the files that contain errors
         -v, --version     Print the version of Standard
         -h, --help        Print this message
         FILE              Files to lint [default: ./]


### PR DESCRIPTION
I couldn't remember the name of this CLI argument so I ran `standardrb --help` and noticed `--generate-todo` wasn't there. Any reason to exclude it from the `--help` output?

The help text is taken directly from the README for consistency:
https://github.com/testdouble/standard/blame/4af3f6c2a3e5c80450897165d1244a42957ddc4b/README.md#L94