### PR TITLE
update rubocop and rubocop-performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## unreleased
+
+* Update rubocop from 1.18.1 to [1.18.2](https://github.com/rubocop-hq/rubocop/releases/tag/v1.18.2)
+* Update rubocop-performance from 1.11.2 to [1.11.3](https://github.com/rubocop-hq/rubocop-performance/releases/tag/v1.11.3)
+
 ## 1.1.3
 
 * Update rubocop from 1.17.0 to [1.18.1](https://github.com/rubocop-hq/rubocop/releases/tag/v1.18.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     standard (1.1.3)
-      rubocop (= 1.18.1)
-      rubocop-performance (= 1.11.2)
+      rubocop (= 1.18.2)
+      rubocop-performance (= 1.11.3)
 
 GEM
   remote: https://rubygems.org/
@@ -24,7 +24,7 @@ GEM
     rake (13.0.3)
     regexp_parser (2.1.1)
     rexml (3.2.5)
-    rubocop (1.18.1)
+    rubocop (1.18.2)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -35,7 +35,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.7.0)
       parser (>= 3.0.1.1)
-    rubocop-performance (1.11.2)
+    rubocop-performance (1.11.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.11.0)

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "1.18.1"
-  spec.add_dependency "rubocop-performance", "1.11.2"
+  spec.add_dependency "rubocop", "1.18.2"
+  spec.add_dependency "rubocop-performance", "1.11.3"
 end


### PR DESCRIPTION
Just noticed I had an old PR that had a rubocop bug where I was also updating rubocop-performance... and that never got merged! So here's a fresh branch, with an update for both.