### PR TITLE
Make .standard_todo.yml narrow to migrate smoother

### DIFF
--- a/lib/standard/loads_yaml_config.rb
+++ b/lib/standard/loads_yaml_config.rb
@@ -32,7 +32,7 @@ module Standard
         default_ignores: standard_yaml.key?("default_ignores") ? !!standard_yaml["default_ignores"] : true,
         config_root: yaml_path ? Pathname.new(yaml_path).dirname.to_s : nil,
         todo_file: todo_path,
-        todo_ignore_files: todo_yaml["ignore"] || []
+        todo_ignore_files: (todo_yaml["ignore"] || []).map { |f| Hash === f ? f.keys.first : f }
       }
     end
 

--- a/lib/standard/runners/genignore.rb
+++ b/lib/standard/runners/genignore.rb
@@ -10,26 +10,21 @@ module Standard
         temp_file = Tempfile.new("excluded.txt")
         begin
           # Run Rubocop to generate the files with errors into the temp file.
-          config.rubocop_options[:formatters] = [["files", temp_file.path]]
-          config.rubocop_options[:format] = "files"
+          config.rubocop_options[:formatters] = [["json", temp_file.path]]
           config.rubocop_options[:out] = temp_file.path
           exit_code = Runners::Rubocop.new.call(config)
 
-          # Read in the files with errors.  It will have the absolute paths
-          # of the files but we only want the relative path.
-          files_with_errors = temp_file.readlines.map(&:chomp)
-          files_with_errors.map! do |file|
-            # Get the relative file path.  Don't use the
-            # relative_path_from method as it will raise an
-            # error in Ruby 2.4.1 and possibly other versions.
-            #
-            # https://bugs.ruby-lang.org/issues/10011
-            #
-            file.sub(Dir.pwd + File::SEPARATOR, "")
-          end
+          result = JSON.parse(temp_file.read)
+          ignore = result["files"].select { |file|
+            file["offenses"].size > 0
+          }.map { |file|
+            {
+              file["path"] => file["offenses"].map { |o| o["cop_name"] }.uniq
+            }
+          }
 
           # Read the files with errors from the temp file.
-          yaml_format_errors = {"ignore" => files_with_errors}
+          yaml_format_errors = {"ignore" => ignore}
 
           # Regenerate the todo file.
           File.open(".standard_todo.yml", "w") do |file|

--- a/test/fixture/config/t/.standard.yml
+++ b/test/fixture/config/t/.standard.yml
@@ -1,0 +1,3 @@
+ignore:
+  - none_todo_path/**/*
+  - none_todo_file.rb

--- a/test/fixture/config/t/.standard_todo.yml
+++ b/test/fixture/config/t/.standard_todo.yml
@@ -1,0 +1,4 @@
+ignore:
+  - todo_file_one.rb:
+      - Lint/AssignmentInCondition
+  - todo_file_two.rb

--- a/test/fixture/genignore/errors_two.rb
+++ b/test/fixture/genignore/errors_two.rb
@@ -1,1 +1,2 @@
 useless_assignment = "LOL"
+useless_assignment2 = "LOL"

--- a/test/standard/builds_config_test.rb
+++ b/test/standard/builds_config_test.rb
@@ -110,6 +110,22 @@ class Standard::BuildsConfigTest < UnitTest
     }, result.rubocop_config_store.for("").to_h
   end
 
+  def test_todo_with_offenses_merged
+    result = @subject.call([], path("test/fixture/config/t"))
+
+    assert_equal DEFAULT_OPTIONS.merge(
+      todo_file: path("test/fixture/config/t/.standard_todo.yml"),
+      todo_ignore_files: %w[todo_file_one.rb todo_file_two.rb]
+    ), result.rubocop_options
+
+    assert_equal config_store("test/fixture/config/t").dup.tap { |config_store|
+      config_store["AllCops"]["Exclude"] |= [path("test/fixture/config/t/none_todo_path/**/*")]
+      config_store["AllCops"]["Exclude"] |= [path("test/fixture/config/t/none_todo_file.rb")]
+      config_store["AllCops"]["Exclude"] |= [path("test/fixture/config/t/todo_file_two.rb")]
+      config_store["Lint/AssignmentInCondition"]["Exclude"] = [path("test/fixture/config/t/todo_file_one.rb")]
+    }, result.rubocop_config_store.for("").to_h
+  end
+
   private
 
   def config_store(config_root = nil, rubocop_yml = highest_compatible_yml_version, ruby_version = RUBY_VERSION)

--- a/test/standard/runners/genignore_test.rb
+++ b/test/standard/runners/genignore_test.rb
@@ -21,7 +21,7 @@ class Standard::Runners::GenignoreTest < UnitTest
 
     assert File.exist?("tmp/genignore_test/.standard_todo.yml")
 
-    expected_yaml = {"ignore" => %w[errors_one.rb errors_two.rb]}
+    expected_yaml = {"ignore" => [{"errors_one.rb" => ["Lint/AssignmentInCondition"]}, {"errors_two.rb" => ["Lint/UselessAssignment"]}]}
     assert_equal expected_yaml, YAML.load_file("tmp/genignore_test/.standard_todo.yml")
   end
 


### PR DESCRIPTION
Currently, --generate-todo generates todo.yml which ignores all rules.

```
$ cat foo.rb
foo = 'foo'
$ standard --generate-todo
$ cat .standard_todo.yml
# Auto generated files with errors to ignore.
# Remove from this list as you refactor files.
---
ignore:
- foo.rb:
```

This patch makes todo.yml narrow.
It prevents increasing todos.

```
$ cat foo.rb
foo = 'foo'
$ standard --generate-todo
$ cat .standard_todo.yml
# Auto generated files with errors to ignore.
# Remove from this list as you refactor files.
---
ignore:
- foo.rb:
  - Lint/UselessAssignment
  - Style/StringLiterals
```