### PR TITLE
Change case indentation to match if/else

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -60,9 +60,8 @@ Layout/BlockEndNewline:
   Enabled: true
 
 Layout/CaseIndentation:
-  # Disabled because IndentOneStep can't be configured for one-liner cases. See:
-  # https://github.com/rubocop-hq/rubocop/issues/6447
-  Enabled: false
+  Enabled: true
+  EnforcedStyle: end
 
 Layout/ClosingHeredocIndentation:
   Enabled: true

--- a/test/fixture/cli/autocorrectable-bad.rb
+++ b/test/fixture/cli/autocorrectable-bad.rb
@@ -105,3 +105,13 @@ def bad_function(test: true, a:, b:)
     b
   end
 end
+
+def count_carbs(food)
+  carbs = case food
+          when :pancakes
+            23
+          when :mushrooms
+            4
+          end
+  carbs + 1
+end

--- a/test/fixture/cli/autocorrectable-good.rb
+++ b/test/fixture/cli/autocorrectable-good.rb
@@ -95,3 +95,13 @@ def bad_function(a:, b:, test: true)
     b
   end
 end
+
+def count_carbs(food)
+  carbs = case food
+  when :pancakes
+    23
+  when :mushrooms
+    4
+  end
+  carbs + 1
+end


### PR DESCRIPTION
The case/when rules we had in place was inconsistent with the indentation rule for multi-line flow control and multi-line data structure literals (for which all subsequent lines are aligned with the end of the expression as opposed to the beginning). I lost track of this over time but definitely consider the current case shown in #322 to be a bug given how far off the mark it is.

```ruby
# bad
def count_carbs(food)
  carbs = case food
          when :pancakes
            23
          when :mushrooms
            4
          end
  carbs + 1
end

# good
def count_carbs(food)
  carbs = case food
  when :pancakes
    23
  when :mushrooms
    4
  end
  carbs + 1
end
```

This makes the rule significantly more strict than enforcement had been before, so I'm opening a PR for folks' opinions before merging, and suggest a minor bump.

Note, however, that this means that this PR would effectively ban what I personally see as a really aesthetically pleasing indentation pattern, however:

```ruby
# this is allowed but not enforced before patch
case fruit
  when :apple then "🍎"
  when :banana then "🍌"
end

# after merge the above will be autocorrected to this
case fruit
when :apple then "🍎"
when :banana then "🍌"
end
```

Losing the ability to optionally one-indent the `when` clauses is a bummer but it's strictly much more consistent to just require case/when to act like if/else, especially given that there's no enforcement to avoid the example at the top as pointed out in #322

Fixes #322 