### PR TITLE
enable Lint/RedundantCopDisableDirective

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -505,6 +505,9 @@ Lint/RaiseException:
 Lint/RandOne:
   Enabled: true
 
+Lint/RedundantCopDisableDirective:
+  Enabled: true
+
 Lint/RedundantRequireStatement:
   Enabled: true
 


### PR DESCRIPTION
extra rubocop disables that are not needed should be removed