### PR TITLE
avoid overriding rubocop cops by extending them

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,8 +4,6 @@ require_relative "lib/standard/rake"
 
 Rake::TestTask.new(:test) do |t|
   t.warning = false
-  t.libs << "test"
-  t.libs << "lib"
   t.test_files = FileList["test/**/*_test.rb"]
 end
 

--- a/config/base.yml
+++ b/config/base.yml
@@ -342,8 +342,7 @@ Lint/AmbiguousRegexpLiteral:
   Enabled: true
 
 Lint/AssignmentInCondition:
-  Enabled: true
-  AllowSafeAssignment: true
+  Enabled: false
 
 Lint/BigDecimalNew:
   Enabled: true
@@ -758,6 +757,10 @@ Security/YAMLLoad:
 
 Standard/BlockSingleLineBraces:
   Enabled: true
+
+Standard/AssignmentInCondition:
+  Enabled: true
+  AllowSafeAssignment: true
 
 Style/Alias:
   Enabled: true

--- a/lib/standard.rb
+++ b/lib/standard.rb
@@ -1,6 +1,7 @@
 require "rubocop"
 
 require "standard/rubocop/ext"
+require "standard/cop/assignment_in_condition"
 
 require "standard/version"
 require "standard/cli"

--- a/lib/standard/cop/assignment_in_condition.rb
+++ b/lib/standard/cop/assignment_in_condition.rb
@@ -1,0 +1,10 @@
+# shorten the otherwise long and confusing message
+module RuboCop::Cop
+  module Standard
+    class AssignmentInCondition < RuboCop::Cop::Lint::AssignmentInCondition
+      def message(_)
+        "Wrap assignment in parentheses if intentional"
+      end
+    end
+  end
+end

--- a/lib/standard/rubocop/ext.rb
+++ b/lib/standard/rubocop/ext.rb
@@ -1,11 +1,4 @@
 module RuboCop
-  class Cop::Lint::AssignmentInCondition
-    undef_method :message
-    def message(_)
-      "Wrap assignment in parentheses if intentional"
-    end
-  end
-
   class DirectiveComment
     remove_const :DIRECTIVE_COMMENT_REGEXP
     DIRECTIVE_COMMENT_REGEXP = Regexp.new(

--- a/test/standard/builds_config_test.rb
+++ b/test/standard/builds_config_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative "../test_helper"
 
 class Standard::BuildsConfigTest < UnitTest
   DEFAULT_OPTIONS = {

--- a/test/standard/cli_test.rb
+++ b/test/standard/cli_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative "../test_helper"
 require "fileutils"
 
 class Standard::CliTest < UnitTest

--- a/test/standard/comment_directive_test.rb
+++ b/test/standard/comment_directive_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative "../test_helper"
 require "fileutils"
 
 class Standard::CommentDirectiveTest < UnitTest

--- a/test/standard/cop/block_single_line_braces_test.rb
+++ b/test/standard/cop/block_single_line_braces_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative "../../test_helper"
 require "cop_invoker"
 
 class RuboCop::Cop::Standard::BlockSingleLineBracesTest < UnitTest

--- a/test/standard/creates_config_store/configures_ignored_paths_test.rb
+++ b/test/standard/creates_config_store/configures_ignored_paths_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative "../../test_helper"
 
 class Standard::CreatesConfigStore::ConfiguresIgnoredPathsTest < UnitTest
   def setup

--- a/test/standard/creates_config_store_test.rb
+++ b/test/standard/creates_config_store_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative "../test_helper"
 
 class Standard::CreatesConfigStore
   class Test < UnitTest

--- a/test/standard/detects_fixability_test.rb
+++ b/test/standard/detects_fixability_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative "../test_helper"
 
 class Standard::DetectsFixabilityTest < UnitTest
   Offense = Struct.new(:cop_name)

--- a/test/standard/file_finder_test.rb
+++ b/test/standard/file_finder_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative "../test_helper"
 
 class Standard::FileFinderTest < UnitTest
   def setup

--- a/test/standard/formatter_test.rb
+++ b/test/standard/formatter_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative "../test_helper"
 
 class Standard::FormatterTest < UnitTest
   Offense = Struct.new(:corrected?, :line, :real_column, :message, :cop_name)

--- a/test/standard/loads_runner_test.rb
+++ b/test/standard/loads_runner_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative "../test_helper"
 
 class Standard::LoadsRunnerTest < UnitTest
   def setup

--- a/test/standard/loads_yaml_config_test.rb
+++ b/test/standard/loads_yaml_config_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative "../test_helper"
 
 class Standard::LoadsYamlConfigTest < UnitTest
   DEFAULT_STANDARD_CONFIG = {

--- a/test/standard/merges_settings_test.rb
+++ b/test/standard/merges_settings_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative "../test_helper"
 
 class Standard::MergesSettingsTest < UnitTest
   def setup

--- a/test/standard/runners/genignore_test.rb
+++ b/test/standard/runners/genignore_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative "../../test_helper"
 
 require "standard/runners/genignore"
 require "standard/runners/rubocop"

--- a/test/standard/runners/help_test.rb
+++ b/test/standard/runners/help_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative "../../test_helper"
 
 require "standard/runners/help"
 

--- a/test/standard/runners/rubocop_test.rb
+++ b/test/standard/runners/rubocop_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative "../../test_helper"
 
 require "standard/runners/rubocop"
 require "fixture/runner/bad_cop"

--- a/test/standard/runners/version_test.rb
+++ b/test/standard/runners/version_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative "../../test_helper"
 
 require "standard/runners/version"
 

--- a/test/standard_test.rb
+++ b/test/standard_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative "test_helper"
 
 class StandardTest < UnitTest
   def test_loads_stuff

--- a/test/standardrb_test.rb
+++ b/test/standardrb_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative "test_helper"
 require "open3"
 
 class StandardrbTest < UnitTest

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,8 @@ begin
 rescue LoadError
 end
 
+$LOAD_PATH << "test"
+
 require "standard"
 require "gimme"
 require "minitest/autorun"


### PR DESCRIPTION
I looked into ext and did not like the overrides since they modify the original cops, this approach in an alternative.
Downsides:
- uses have to use `# rubocop:disable Standard/AssignmentInCondition`
- cop is no longer under `Lint`