### PR TITLE
enable Style/NumericPredicate with comparison

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -1470,7 +1470,8 @@ Style/NumericLiterals:
   Enabled: false
 
 Style/NumericPredicate:
-  Enabled: false
+  Enabled: true
+  EnforcedStyle: comparison
 
 Style/OneLineConditional:
   Enabled: true
@@ -1789,4 +1790,4 @@ Style/YodaCondition:
   EnforcedStyle: forbid_for_all_comparison_operators
 
 Style/ZeroLengthPredicate:
-  Enabled: false
+  Enabled: false # not safe always fix and both versions are readable


### PR DESCRIPTION
https://docs.rubocop.org/rubocop/1.0/cops_style.html#stylenumericpredicate

Prefer `foo == 0` over `foo.zero?` since anyone can understand the first one and it avoids bugs with foo being `nil` (same for .positive? and .negative?)