### PR TITLE
silence rubygems version warning

### DIFF
--- a/lib/standard/loads_yaml_config.rb
+++ b/lib/standard/loads_yaml_config.rb
@@ -37,9 +37,9 @@ module Standard
     end
 
     def normalized_ruby_version(version)
-      return version unless Gem::Version.correct?(version)
+      return version if version && !Gem::Version.correct?(version)
 
-      Gem::Version.new((version || RUBY_VERSION))
+      Gem::Version.new(version || RUBY_VERSION)
     end
 
     def expand_ignore_config(ignore_config)


### PR DESCRIPTION
tons of these 😞 
```
nil versions are discouraged and will be deprecated in Rubygems 4
```