### PR TITLE
disable Style/NegatedIf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+* Remove
+  [`Style/NegatedIf`](https://github.com/TODO)
+
 ## 1.3.0
 
 * Update rubocop from 1.19.1 to [1.20.0](https://github.com/rubocop-hq/rubocop/releases/tag/v1.20.0)

--- a/config/base.yml
+++ b/config/base.yml
@@ -1406,8 +1406,7 @@ Style/MutableConstant:
   Enabled: false
 
 Style/NegatedIf:
-  Enabled: true
-  EnforcedStyle: postfix
+  Enabled: false
 
 Style/NegatedIfElseCondition:
   Enabled: false


### PR DESCRIPTION
Standard currently rejects `if !foo` and replaces it with `unless foo`. This disables that behavior.

One reason is that although they are simple logical inverses, `unless` is inherently more mentally taxing than `if`, and some programmers prefer to use `if` most of the time.

Those of us in this camp often find ourselves mentally rewriting `unless` as we read code. It's not optimal.

A [short thread on Twitter](https://twitter.com/searls/status/1449516056788209664) this weekend suggested Standard might be open to modifying this rule, so here's a PR to have that discussion.