### PR TITLE
Update rubocop-performance gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 * Remove
   [`Style/NegatedIf`](https://github.com/TODO)
 
+## 1.4.1
+
+* loosen constraint on rubocop-performance to support [1.12.0](https://github.com/rubocop/rubocop-performance/releases/tag/v1.12.0)
+* update gems in gemfile.
+
 ## 1.4.0
 
 * Update rubocop from 1.19.1 to [1.22.3](https://github.com/rubocop-hq/rubocop/releases/tag/v1.22.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     standard (1.4.0)
       rubocop (= 1.22.3)
-      rubocop-performance (~> 1.12)
+      rubocop-performance (= 1.11.5)
 
 GEM
   remote: https://rubygems.org/
@@ -15,7 +15,7 @@ GEM
     method_source (1.0.0)
     minitest (5.14.4)
     parallel (1.21.0)
-    parser (3.0.3.1)
+    parser (3.0.2.0)
       ast (~> 2.4.1)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -33,9 +33,9 @@ GEM
       rubocop-ast (>= 1.12.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.13.0)
+    rubocop-ast (1.12.0)
       parser (>= 3.0.1.1)
-    rubocop-performance (1.12.0)
+    rubocop-performance (1.11.5)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.11.0)
@@ -61,4 +61,4 @@ DEPENDENCIES
   standard!
 
 BUNDLED WITH
-   2.2.23
+   2.2.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    standard (1.4.0)
+    standard (1.4.1)
       rubocop (= 1.22.3)
-      rubocop-performance (= 1.11.5)
+      rubocop-performance (~> 1.12)
 
 GEM
   remote: https://rubygems.org/
@@ -15,7 +15,7 @@ GEM
     method_source (1.0.0)
     minitest (5.14.4)
     parallel (1.21.0)
-    parser (3.0.2.0)
+    parser (3.0.3.1)
       ast (~> 2.4.1)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -33,9 +33,9 @@ GEM
       rubocop-ast (>= 1.12.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.12.0)
+    rubocop-ast (1.13.0)
       parser (>= 3.0.1.1)
-    rubocop-performance (1.11.5)
+    rubocop-performance (1.12.0)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.11.0)
@@ -61,4 +61,4 @@ DEPENDENCIES
   standard!
 
 BUNDLED WITH
-   2.2.22
+   2.2.23

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     standard (1.4.0)
       rubocop (= 1.22.3)
-      rubocop-performance (= 1.11.5)
+      rubocop-performance (~> 1.12)
 
 GEM
   remote: https://rubygems.org/
@@ -15,7 +15,7 @@ GEM
     method_source (1.0.0)
     minitest (5.14.4)
     parallel (1.21.0)
-    parser (3.0.2.0)
+    parser (3.0.3.1)
       ast (~> 2.4.1)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -33,9 +33,9 @@ GEM
       rubocop-ast (>= 1.12.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.12.0)
+    rubocop-ast (1.13.0)
       parser (>= 3.0.1.1)
-    rubocop-performance (1.11.5)
+    rubocop-performance (1.12.0)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.11.0)
@@ -61,4 +61,4 @@ DEPENDENCIES
   standard!
 
 BUNDLED WITH
-   2.2.22
+   2.2.23

--- a/config/base.yml
+++ b/config/base.yml
@@ -923,6 +923,9 @@ Performance/CollectionLiteralInLoop:
 Performance/CompareWithBlock:
   Enabled: true
 
+Performance/ConcurrentMonotonicTime:
+  Enabled: true
+
 Performance/ConstantRegexp:
   Enabled: true
 

--- a/lib/standard/version.rb
+++ b/lib/standard/version.rb
@@ -1,3 +1,3 @@
 module Standard
-  VERSION = Gem::Version.new("1.4.0")
+  VERSION = Gem::Version.new("1.4.1")
 end

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubocop", "1.22.3"
-  spec.add_dependency "rubocop-performance", "1.11.5"
+  spec.add_dependency "rubocop-performance", "~> 1.12"
 end


### PR DESCRIPTION
# What

* use 1.12.x for rubocop-performance.

# Why

It's the most recent version and bugfix versions, generally speaking, should be allowable (i.e. use `~>` instead of `=`).