### PR TITLE
Update section about usage via rubocop

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,6 @@ project healthier.
 ## Usage via rubocop
 
 If you only want to use the rules and not the cli (to keep current IDE/tooling/workflow support).
-It needs to repeat `AllCops` because of a [rubocop issue](https://github.com/rubocop/rubocop/issues/10175).
 Change your `.rubocop.yml` to:
 
 ```yaml
@@ -201,9 +200,6 @@ require: standard
 
 inherit_gem:
   standard: config/base.yml
-
-AllCops:
-  DisabledByDefault: true
 ```
 
 ## Who uses Ruby Standard Style?


### PR DESCRIPTION
`DisabledByDefault: true` was removed from config/base.yml in https://github.com/testdouble/standard/commit/2445c16420428d75bd68208f069fc02d069c5a63. According to https://github.com/testdouble/standard/issues/332 this was intentionally.

I think it's no longer necessary to add it to the rubocop config file here.