### PR TITLE
Remove duplicate `Naming/BlockForwarding` in `config/ruby-3.0.yml`

### DIFF
--- a/config/ruby-3.0.yml
+++ b/config/ruby-3.0.yml
@@ -8,6 +8,3 @@ Style/HashExcept:
 
 Naming/BlockForwarding:
   Enabled: false
-
-Naming/BlockForwarding:
-  Enabled: false


### PR DESCRIPTION
When running the latest Standard 1.6.0, I get this warning:

```
standard-1.6.0/config/ruby-3.0.yml:9: `Naming/BlockForwarding` is concealed by line 12
```

I discovered that there is a duplicate declaration in the `ruby-3.0.yml` file.