### PR TITLE
Ensure that CI runs a 3.0.x version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        ruby-version: [2.5, 2.6, 2.7, 3.0, 3.1]
+        ruby-version: [2.5, 2.6, 2.7, '3.0', 3.1]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Because YAML truncates trailing zeroes in numerical values, an unquoted 3.0 is treated a 3.  This loss of precision means that the actual version of Ruby loaded will be the most recently release 3.x version - at this time 3.1.0.

Quoting the '3.0' restores the precision.