### PR TITLE
Removes RedundantBegin from Ruby 2.4 and below

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Removes Style/RedundantBegin from Ruby versions <= 2.4
+
 ## 1.7.1
 
 * Update rubocop from 1.25.0 to [1.25.1](https://github.com/rubocop/rubocop/tag/v1.25.1)

--- a/config/ruby-2.4.yml
+++ b/config/ruby-2.4.yml
@@ -2,3 +2,6 @@ inherit_from: ./ruby-2.5.yml
 
 AllCops:
   TargetRubyVersion: 2.5 # The oldest supported
+
+Style/RedundantBegin:
+  Enabled: false


### PR DESCRIPTION
Rubocop has dropped support for Ruby <2.5 so this cop no longer
functions safely on Ruby 2.4 and below.