### PR TITLE
enforce :"foo-bar" over :'foo-bar' to be consistent with other doubl…

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -1552,7 +1552,8 @@ Style/Proc:
   Enabled: true
 
 Style/QuotedSymbols:
-  Enabled: false
+  Enabled: true
+  EnforcedStyle: same_as_string_literals
 
 Style/RaiseArgs:
   Enabled: false

--- a/test/fixture/quoted_symbols/test.rb
+++ b/test/fixture/quoted_symbols/test.rb
@@ -1,0 +1,3 @@
+a = :"good-d"
+b = :'bad-d'
+puts a + b

--- a/test/standardrb_test.rb
+++ b/test/standardrb_test.rb
@@ -32,6 +32,14 @@ class StandardrbTest < UnitTest
     MSG
   end
 
+  def test_quoted_symbols_are_enforced
+    stdout, status = run_standardrb("test/fixture/quoted_symbols")
+    refute status.success?, stdout
+    assert_equal stdout.scan(/.*\.rb.*/), [
+      "  test.rb:2:5: Style/QuotedSymbols: Prefer double-quoted symbols unless you need single quotes to avoid extra backslashes for escaping."
+    ]
+  end
+
   private
 
   def run_standardrb(cwd, args = [])


### PR DESCRIPTION
…e-quoting rules


```
-'Impersonate-User': IMPERSONATE_USER,
+"Impersonate-User": IMPERSONATE_USER,
```