### PR TITLE
Disable TrailingComma* cops

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -1816,19 +1816,16 @@ Style/TrailingBodyOnModule:
   Enabled: true
 
 Style/TrailingCommaInArguments:
-  Enabled: true
-  EnforcedStyleForMultiline: no_comma
+  Enabled: false
 
 Style/TrailingCommaInArrayLiteral:
-  Enabled: true
-  EnforcedStyleForMultiline: no_comma
+  Enabled: false
 
 Style/TrailingCommaInBlockArgs:
   Enabled: true
 
 Style/TrailingCommaInHashLiteral:
-  Enabled: true
-  EnforcedStyleForMultiline: no_comma
+  Enabled: false
 
 Style/TrailingMethodEndStatement:
   Enabled: true

--- a/lib/standard/version.rb
+++ b/lib/standard/version.rb
@@ -1,3 +1,3 @@
 module Standard
-  VERSION = Gem::Version.new('1.16.1')
+  VERSION = Gem::Version.new("1.16.1")
 end

--- a/test/fixture/cli/autocorrectable-good.rb
+++ b/test/fixture/cli/autocorrectable-good.rb
@@ -6,12 +6,12 @@ STUFF = [
   1,
   3,
   4,
-  5
+  5,
 ]
 
 THINGS = {
   oh: :io,
-  hi: "neat"
+  hi: "neat",
 }
 
 class Something
@@ -70,7 +70,7 @@ class AlignyStuff
     thing_1: 0,
     thing_2: 1,
     longer_thing: 2,
-    even_longer_thing: 3
+    even_longer_thing: 3,
   }
 
   def setup_fog_credentials(config)
@@ -78,14 +78,14 @@ class AlignyStuff
       provider: "AWS",
       aws_access_key_id: ENV["S3_ACCESS_KEY"],
       aws_secret_access_key: ENV["S3_SECRET"],
-      region: ENV["S3_REGION"]
+      region: ENV["S3_REGION"],
     }
 
     config.fog_credentials_as_kwargs(
       provider: "AWS",
       aws_access_key_id: ENV["S3_ACCESS_KEY"],
       aws_secret_access_key: ENV["S3_SECRET"],
-      region: ENV["S3_REGION"]
+      region: ENV["S3_REGION"],
     )
   end
 end


### PR DESCRIPTION
These cops used to be configured with `EnforcedStyleForMultiline: consistent_comma` but it was changed in https://github.com/testdouble/standard/commit/a7156b14528f4b171567c528f6a2434a43b6e54a because it can cause some weird contortions, see: https://github.com/testdouble/standard/issues/133

I totally agree that this cop resulting in such horrible contorsion is broken, but I don't understand why that would justify to switch to a different style rather than to just disable the cop.

Trailing comma in multiline hashes & co have the major advantage of reducing diff noise when adding or removing an element.

NB: I'm not too sure if it's ok to open PRs to argue about style, but since this used to be the preferable style and was changed for a technicality, I hope it's ok.