### PR TITLE
Fix autocorrect fixture so disable comments are preserved

### DIFF
--- a/test/fixture/cli/autocorrectable-bad.rb
+++ b/test/fixture/cli/autocorrectable-bad.rb
@@ -1,7 +1,5 @@
 #Some code that violates lots of rules
 
-require "json" # standard:disable Lint/AssignmentInCondition
-
 STUFF = [
   1,
           3,

--- a/test/fixture/cli/autocorrectable-good.rb
+++ b/test/fixture/cli/autocorrectable-good.rb
@@ -1,7 +1,5 @@
 # Some code that violates lots of rules
 
-require "json"
-
 STUFF = [
   1,
   3,


### PR DESCRIPTION
Based on my understanding of 8e37104, this test was accurately failing because we want these disable comments to be preserved after autocorrect.