### PR TITLE
LSP server

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     standard (1.16.1)
+      language_server-protocol (= 3.17.0.1)
       rubocop (= 1.35.1)
       rubocop-performance (= 1.14.3)
 
@@ -13,6 +14,7 @@ GEM
     docile (1.4.0)
     gimme (0.5.0)
     json (2.6.2)
+    language_server-protocol (3.17.0.1)
     method_source (1.0.0)
     minitest (5.16.3)
     parallel (1.22.1)

--- a/lib/standard/lsp/server.rb
+++ b/lib/standard/lsp/server.rb
@@ -15,8 +15,8 @@ module Standard
 
       def initialize(standardizer)
         self.standardizer = standardizer
-        self.writer = Proto::Transport::Stdio::Writer.new
-        self.reader = Proto::Transport::Stdio::Reader.new
+        self.writer = Proto::Transport::Io::Writer.new($stdout)
+        self.reader = Proto::Transport::Io::Reader.new($stdin)
         self.logger = $stderr
         self.text_cache = {}
 
@@ -98,6 +98,7 @@ module Standard
 
         lsp_diagnostics = offenses.map do |o|
           code = o[:cop_name]
+
           msg = o[:message].delete_prefix(code)
           loc = o[:location]
 

--- a/lib/standard/lsp/server.rb
+++ b/lib/standard/lsp/server.rb
@@ -1,0 +1,140 @@
+require "language_server-protocol"
+require_relative "standardizer"
+
+module Standard
+  module LSP
+    class Server
+      Proto = LanguageServer::Protocol
+      SEV = Proto::Constant::DiagnosticSeverity
+
+      def self.start(standardizer)
+        new(standardizer).start
+      end
+
+      attr_accessor :standardizer, :writer, :reader, :logger, :text_cache, :subscribers
+
+      def initialize(standardizer)
+        self.standardizer = standardizer
+        self.writer = Proto::Transport::Stdio::Writer.new
+        self.reader = Proto::Transport::Stdio::Reader.new
+        self.logger = $stderr
+        self.text_cache = {}
+
+        self.subscribers = {
+          "initialize" => ->(request) {
+            init_result = Proto::Interface::InitializeResult.new(
+              capabilities: Proto::Interface::ServerCapabilities.new(
+                document_formatting_provider: true,
+                diagnostic_provider: true,
+                text_document_sync: Proto::Constant::TextDocumentSyncKind::FULL
+              )
+            )
+            writer.write(id: request[:id], result: init_result)
+          },
+
+          "initialized" => ->(request) { logger.puts "standard v#{Standard::VERSION} initialized, pid #{Process.pid}" },
+
+          "shutdown" => ->(request) {
+            logger.puts "asked to shutdown, exiting..."
+            exit
+          },
+
+          "textDocument/didChange" => ->(request) {
+            params = request[:params]
+            result = diagnostic(params[:textDocument][:uri], params[:contentChanges][0][:text])
+            writer.write(result)
+          },
+
+          "textDocument/didOpen" => ->(request) {
+            td = request[:params][:textDocument]
+            result = diagnostic(td[:uri], td[:text])
+            writer.write(result)
+          },
+
+          "textDocument/didClose" => ->(request) {
+            text_cache.delete request[:params][:textDocument][:uri]
+          },
+
+          "textDocument/formatting" => ->(request) {
+            uri = request[:params][:textDocument][:uri]
+            writer.write({id: request[:id], result: format_file(uri)})
+          },
+
+          "textDocument/didSave" => ->(request) {}
+        }
+      end
+
+      def start
+        reader.read do |request|
+          method = request[:method]
+          if (subscriber = subscribers[method])
+            subscriber.call(request)
+          else
+            logger.puts "unknown method: #{method}"
+          end
+        rescue => e
+          logger.puts "error #{e.class} #{e.message[0..100]}"
+          logger.puts e.backtrace.inspect
+        end
+      end
+
+      def format_file(file_uri)
+        text = text_cache[file_uri]
+        new_text = standardizer.format text
+
+        if new_text == text
+          []
+        else
+          [{
+            newText: new_text,
+            range: {start: {line: 0, character: 0}, end: {line: text.count("\n") + 1, character: 0}}
+          }]
+        end
+      end
+
+      def diagnostic(file_uri, text)
+        text_cache[file_uri] = text
+        offenses = standardizer.offenses text
+
+        lsp_diagnostics = offenses.map do |o|
+          code = o[:cop_name]
+          msg = o[:message].delete_prefix(code)
+          loc = o[:location]
+
+          severity = case o[:severity]
+          when "error", "fatal"
+            SEV::ERROR
+          when "warning"
+            SEV::WARNING
+          when "convention"
+            SEV::INFORMATION
+          when "refactor", "info"
+            SEV::HINT
+          else # the above cases fully cover what RuboCop sends at this time
+            logger.puts "unknown severity: #{severity.inspect}"
+            SEV::HINT
+          end
+
+          {
+            code: code,
+            message: msg,
+            range: {
+              start: {character: loc[:start_column] - 1, line: loc[:start_line] - 1},
+              end: {character: loc[:last_column] - 1, line: loc[:last_line] - 1}
+            },
+            severity: severity,
+            source: "standard"
+          }
+        end
+
+        {
+          method: "textDocument/publishDiagnostics",
+          params: {
+            diagnostics: lsp_diagnostics,
+            uri: file_uri
+          }
+        }
+      end
+    end
+  end
+end

--- a/lib/standard/lsp/standardizer.rb
+++ b/lib/standard/lsp/standardizer.rb
@@ -1,0 +1,52 @@
+require_relative "../runners/rubocop"
+require "tempfile"
+
+module Standard
+  module LSP
+    class Standardizer
+      def initialize(config)
+        @template_options = config
+        @runner = Standard::Runners::Rubocop.new
+      end
+
+      def format(text)
+        run_standard text, format: true
+      end
+
+      def offenses(text)
+        results = run_standard text, format: false
+        JSON.parse(results, symbolize_names: true)[:files][0][:offenses]
+      end
+
+      private
+
+      BASENAME = ["source", ".rb"].freeze
+      def run_standard(text, format:)
+        Tempfile.open(BASENAME) do |temp|
+          temp.write text
+          stdout = capture_rubocop_stdout make_config(temp.path, format)
+          format ? File.read(temp.path) : stdout
+        end
+      end
+
+      def make_config(file, format)
+        # can't make frozen versions of these hashes because rubocop mutates them
+        o = if format
+          {autocorrect: true, formatters: [["Standard::Formatter", nil]], parallel: true, todo_file: nil, todo_ignore_files: [], safe_autocorrect: true}
+        else
+          {autocorrect: false, formatters: [["json"]], parallel: true, todo_file: nil, todo_ignore_files: [], format: "json"}
+        end
+        Standard::Config.new(@template_options.runner, [file], o, @template_options.rubocop_config_store)
+      end
+
+      def capture_rubocop_stdout(config)
+        redir = StringIO.new
+        $stdout = redir
+        @runner.call config
+        redir.string
+      ensure
+        $stdout = STDOUT
+      end
+    end
+  end
+end

--- a/lib/standard/lsp/standardizer.rb
+++ b/lib/standard/lsp/standardizer.rb
@@ -24,6 +24,7 @@ module Standard
       def run_standard(text, format:)
         Tempfile.open(BASENAME) do |temp|
           temp.write text
+          temp.flush
           stdout = capture_rubocop_stdout make_config(temp.path, format)
           format ? File.read(temp.path) : stdout
         end

--- a/lib/standard/merges_settings.rb
+++ b/lib/standard/merges_settings.rb
@@ -20,7 +20,7 @@ module Standard
 
     def separate_argv(argv)
       argv.partition do |flag|
-        ["--generate-todo", "--fix", "--no-fix", "--version", "-v", "--help", "-h"].include?(flag)
+        ["--generate-todo", "--fix", "--no-fix", "--version", "-v", "--help", "-h", "--lsp"].include?(flag)
       end
     end
 
@@ -41,6 +41,8 @@ module Standard
         :version
       elsif (argv & ["--generate-todo"]).any?
         :genignore
+      elsif (argv & ["--lsp"]).any?
+        :lsp
       else
         :rubocop
       end

--- a/lib/standard/runners/help.rb
+++ b/lib/standard/runners/help.rb
@@ -4,8 +4,8 @@ module Standard
   module Runners
     class Help
       def call(config)
-        puts <<-MESSAGE.gsub(/^ {10}/, "")
-          Usage: standardrb [--fix] [-vh] [--format <name>] [--] [FILE]...
+        puts <<~MESSAGE
+          Usage: standardrb [--fix] [--lsp] [-vh] [--format <name>] [--] [FILE]...
 
           Options:
 
@@ -13,6 +13,7 @@ module Standard
             --no-fix          Do not automatically fix failures
             --format <name>   Format output with any RuboCop formatter (e.g. "json")
             --generate-todo   Create a .standard_todo.yml that lists all the files that contain errors
+            --lsp             Start a LSP server listening on STDIN
             -v, --version     Print the version of Standard
             -h, --help        Print this message
             FILE              Files to lint [default: ./]

--- a/lib/standard/runners/lsp.rb
+++ b/lib/standard/runners/lsp.rb
@@ -1,0 +1,12 @@
+require_relative "../lsp/server"
+
+module Standard
+  module Runners
+    class Lsp
+      def call(config)
+        standardizer = Standard::LSP::Standardizer.new(config)
+        Standard::LSP::Server.start(standardizer)
+      end
+    end
+  end
+end

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -21,4 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rubocop", "1.35.1"
   spec.add_dependency "rubocop-performance", "1.14.3"
+
+  # not semver: first three are lsp protocol version, last is patch
+  spec.add_dependency "language_server-protocol", "3.17.0.1"
 end

--- a/test/standard/runners/help_test.rb
+++ b/test/standard/runners/help_test.rb
@@ -12,8 +12,8 @@ class Standard::Runners::HelpTest < UnitTest
       @subject.call(nil)
     }
 
-    expected = <<-MESSAGE.gsub(/^ {6}/, "")
-      Usage: standardrb [--fix] [-vh] [--format <name>] [--] [FILE]...
+    expected = <<~MESSAGE
+      Usage: standardrb [--fix] [--lsp] [-vh] [--format <name>] [--] [FILE]...
 
       Options:
 
@@ -21,6 +21,7 @@ class Standard::Runners::HelpTest < UnitTest
         --no-fix          Do not automatically fix failures
         --format <name>   Format output with any RuboCop formatter (e.g. "json")
         --generate-todo   Create a .standard_todo.yml that lists all the files that contain errors
+        --lsp             Start a LSP server listening on STDIN
         -v, --version     Print the version of Standard
         -h, --help        Print this message
         FILE              Files to lint [default: ./]

--- a/test/standard/runners/lsp_test.rb
+++ b/test/standard/runners/lsp_test.rb
@@ -1,0 +1,155 @@
+require_relative "../../test_helper"
+
+require "standard/runners/lsp"
+
+class Standard::Runners::LspTest < UnitTest
+  def test_server_initializes_and_responds_with_proper_capabilities
+    msgs, err = run_server_on_requests({
+      id: 2,
+      jsonrpc: "2.0",
+      method: "initialize",
+      params: {probably: "don't need real params for this test?"}
+    })
+
+    assert_equal "", err.string
+    assert_equal 1, msgs.count
+    assert_equal msgs.first, {
+      id: 2,
+      result: {capabilities: {
+        textDocumentSync: 1,
+        documentFormattingProvider: true,
+        diagnosticProvider: true
+      }},
+      jsonrpc: "2.0"
+    }
+  end
+
+  def test_get_diagnostics
+    msgs, err = run_server_on_requests({
+      method: "textDocument/didOpen",
+      jsonrpc: "2.0",
+      params: {
+        textDocument: {
+          languageId: "ruby",
+          text: "def hi\n  [1, 2,\n   3  ]\nend\n",
+          uri: "file:///path/to/file.rb",
+          version: 0
+        }
+      }
+    })
+
+    assert_equal "", err.string
+    assert_equal 1, msgs.count
+    assert_equal({
+      method: "textDocument/publishDiagnostics",
+      params: {
+        diagnostics: [
+          {code: "Layout/ArrayAlignment",
+           message: "Use one level of indentation for elements following the first line of a multi-line array.",
+           range: {start: {character: 3, line: 2}, end: {character: 3, line: 2}},
+           severity: 3,
+           source: "standard"},
+          {code: "Layout/ExtraSpacing",
+           message: "Unnecessary spacing detected.",
+           range: {start: {character: 4, line: 2}, end: {character: 4, line: 2}},
+           severity: 3,
+           source: "standard"},
+          {code: "Layout/SpaceInsideArrayLiteralBrackets",
+           message: "Do not use space inside array brackets.",
+           range: {start: {character: 4, line: 2}, end: {character: 5, line: 2}},
+           severity: 3,
+           source: "standard"}
+        ],
+        uri: "file:///path/to/file.rb"
+      },
+      jsonrpc: "2.0"
+    }, msgs.first)
+  end
+
+  def test_format
+    msgs, err = run_server_on_requests(
+      {
+        method: "textDocument/didOpen",
+        jsonrpc: "2.0",
+        params: {
+          textDocument: {
+            languageId: "ruby",
+            text: "def hi\n  [1, 2,\n   3  ]\nend\n",
+            uri: "file:///path/to/file.rb",
+            version: 0
+          }
+        }
+      },
+      {
+        method: "textDocument/didChange",
+        jsonrpc: "2.0",
+        params: {
+          contentChanges: [{text: "def goodbye\n  [3, 2,\n   1  ]\n\nend\n"}],
+          textDocument: {
+            uri: "file:///path/to/file.rb",
+            version: 10
+          }
+        }
+      },
+      {
+        method: "textDocument/formatting",
+        id: 20,
+        jsonrpc: "2.0",
+        params: {
+          options: {insertSpaces: true, tabSize: 2},
+          textDocument: {uri: "file:///path/to/file.rb"}
+        }
+      }
+    )
+
+    assert_equal "", err.string
+    format_result = msgs.last
+    assert_equal(
+      {
+        id: 20,
+        result: [
+          {newText: "def goodbye\n  [3, 2,\n    1]\nend\n",
+           range: {
+             start: {line: 0, character: 0},
+             end: {line: 6, character: 0}
+           }}
+        ],
+        jsonrpc: "2.0"
+      },
+      format_result
+    )
+  end
+
+  private
+
+  def run_server_on_requests(*requests)
+    stdin = StringIO.new(requests.map { |r| to_jsonrpc(r) }.join)
+    out, err, _ = do_with_fake_io(stdin) do
+      Standard::Runners::Lsp.new.call(create_config)
+    end
+
+    msgs = parse_jsonrpc_messages(out)
+
+    [msgs, err]
+  end
+
+  BASE_CONFIG = Standard::BuildsConfig.new.call(["-a", "some_file_name.rb"])
+
+  def create_config(options = {})
+    Standard::Config.new(nil, ["unused_file_name.rb"], options, BASE_CONFIG.rubocop_config_store)
+  end
+
+  def to_jsonrpc(hash)
+    hash_str = hash.to_json
+
+    "Content-Length: #{hash_str.bytesize}\r\n\r\n#{hash_str}"
+  end
+
+  def parse_jsonrpc_messages(io)
+    io.rewind
+    reader = LanguageServer::Protocol::Transport::Io::Reader.new(io)
+    messages = []
+    reader.read { |msg| messages << msg }
+    messages
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,17 +31,17 @@ class UnitTest < Minitest::Test
     self.class.path(relative)
   end
 
-  def do_with_fake_io
-    og_stdout, og_stderr = $stdout, $stderr
+  def do_with_fake_io(fake_in = $stdin)
+    og_stdin, og_stdout, og_stderr = $stdin, $stdout, $stderr
     fake_out, fake_err = StringIO.new, StringIO.new
 
-    $stdout, $stderr = fake_out, fake_err
+    $stdin, $stdout, $stderr = fake_in, fake_out, fake_err
     result = yield
-    $stdout, $stderr = og_stdout, og_stderr
+    $stdin, $stdout, $stderr = og_stdin, og_stdout, og_stderr
 
     [fake_out, fake_err, result]
   ensure
-    $stdout, $stderr = og_stdout, og_stderr
+    $stdin, $stdout, $stderr = og_stdin, og_stdout, og_stderr
   end
 
   def standard_greeting


### PR DESCRIPTION
This adds an LSP server that runs with the flag `--lsp`. It does the lsp jsonrpc over stdio. Functionality wise, this works for everything I need. I've only tested with neovim 0.8 though. It only operates on documents that you open, rather than going through your entire project looking for ruby files. 

Test coverage isn't great, but I think they cover the major parts:

* telling the lsp client (an editor) on init what the server supports and to send full documents instead of patches
* getting diagnostics
* formatting

_I'm_ okay with this level of testing to start, but I'd understand if you weren't.

I think this is a good starting point for functionality, but there some improvements left on the table:

If several changes come in while it was doing some other work, the stdin reader could collapse the changes and only take the last full change.

Editors could just send the small changes on each change, but then the server would have to be able to patch those into the copy it has in memory. Not impossible, but defiantly a lot more work. Would also make the previous collapsing improvement not necessary.

Format results could also be a series of patches rather than the entire document.

It could go through and find all the files in your workspace, but idk, I think just working on open files is good enough.

It might be possible to do the diagnostics and formatting in memory rather than bouncing through a tempfile. The solargraph moneky patch I was using before did this originally, but it stopped working and I couldn't figure out why, which lead me down to writing a small lsp form scratch in the first place.

Also please let me know what sort of git etiquette you'd like for changes on the PR. rebasing into the original commit or fixup additional patches or whatnot.

closes #472