### PR TITLE
Update rubocop to 1.37.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     standard (1.16.1)
-      rubocop (= 1.35.1)
+      rubocop (= 1.37.1)
       rubocop-performance (= 1.14.3)
 
 GEM
@@ -23,19 +23,19 @@ GEM
       method_source (~> 1.0)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.5.0)
+    regexp_parser (2.6.0)
     rexml (3.2.5)
-    rubocop (1.35.1)
+    rubocop (1.37.1)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.1.2.1)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.20.1, < 2.0)
+      rubocop-ast (>= 1.23.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.21.0)
+    rubocop-ast (1.23.0)
       parser (>= 3.1.1.0)
     rubocop-performance (1.14.3)
       rubocop (>= 1.7.0, < 2.0)
@@ -47,7 +47,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    unicode-display_width (2.2.0)
+    unicode-display_width (2.3.0)
 
 PLATFORMS
   ruby

--- a/config/base.yml
+++ b/config/base.yml
@@ -493,6 +493,9 @@ Lint/DuplicateElsifCondition:
 Lint/DuplicateHashKey:
   Enabled: true
 
+Lint/DuplicateMagicComment:
+  Enabled: true
+
 Lint/DuplicateMethods:
   Enabled: true
 
@@ -1569,6 +1572,9 @@ Style/OneLineConditional:
 Style/OpenStructUse:
   Enabled: false
 
+Style/OperatorMethodCall:
+  Enabled: true
+
 Style/OptionHash:
   Enabled: false
 
@@ -1686,6 +1692,9 @@ Style/RedundantSort:
   Enabled: true
 
 Style/RedundantSortBy:
+  Enabled: true
+
+Style/RedundantStringEscape:
   Enabled: true
 
 Style/RegexpLiteral:

--- a/standard.gemspec
+++ b/standard.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "1.35.1"
+  spec.add_dependency "rubocop", "1.37.1"
   spec.add_dependency "rubocop-performance", "1.14.3"
 end


### PR DESCRIPTION
This patch updates rubocop to `1.37.1`. I tried updating to the latest rubocop (`1.38.0`) but there appears to be a bug in rubocop which raises an exception when running the test suite, so it should likely be avoided until `1.38.1`.