### PR TITLE
Enable Extra Spacing Before Trailing Comments

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -182,7 +182,7 @@ Layout/EndOfLine:
 Layout/ExtraSpacing:
   Enabled: true
   AllowForAlignment: false
-  AllowBeforeTrailingComments: false
+  AllowBeforeTrailingComments: true
   ForceEqualSignAlignment: false
 
 Layout/FirstArgumentIndentation:


### PR DESCRIPTION
## Summary

The `AllowBeforeTrailingComments` flag for `Layout/ExtraSpacing` was explicitly disabled in https://github.com/testdouble/standard/pull/125, as part of a bulk change to add Rubocop's defaults. 

I think this should be explicitly set to `true`. It allows for better grouping of comments when they trail.

## Example of Before and After
 
**Before**

```ruby
class Student < ApplicationRecord
  has_one :counselor, class: "Faculty" # The guidance counselor helps a student pick their classes
  has_one :school # A student can only be enrolled in one school at a time
  has_many :classes # A student needs to be enrolled in classes
  has_one :homeroom, class: "Class" # A student starts each day of school in their homeroom
end
```

**After**

```ruby
class Student < ApplicationRecord
  has_one :counselor, class: "Faculty"   # The guidance counselor helps a student pick their classes
  has_one :school                        # A student can only be enrolled in one school at a time
  has_many :classes                      # A student needs to be enrolled in classes
  has_one :homeroom, class: "Class"      # A student starts each day of school in their homeroom
end
```

I think this leads to more readable code when using trailing commas.