### PR TITLE
Fix standard directives being ignored in files without any rubocop reference

### DIFF
--- a/lib/standard/rubocop/ext.rb
+++ b/lib/standard/rubocop/ext.rb
@@ -13,4 +13,13 @@ module RuboCop
         .gsub(" ", '\s*')
     )
   end
+
+  class CommentConfig
+    alias_method :old_initialize, :initialize
+
+    def initialize(processed_source)
+      old_initialize(processed_source)
+      @no_directives &&= !processed_source.raw_source.include?("standard")
+    end
+  end
 end

--- a/test/fixture/comment_directive_test/isolated.rb
+++ b/test/fixture/comment_directive_test/isolated.rb
@@ -1,0 +1,7 @@
+foo = 42 # standard:disable Lint/UselessAssignment
+
+# standard:disable Layout/IndentationWidth
+def foo
+    123
+end
+# standard:enable Layout/IndentationWidth

--- a/test/standard/comment_directive_test.rb
+++ b/test/standard/comment_directive_test.rb
@@ -15,4 +15,14 @@ class Standard::CommentDirectiveTest < UnitTest
         test/fixture/comment_directive_test/disabled.rb:11:1: Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
     OUTPUT
   end
+
+  def test_isolated_directive
+    fake_out, fake_err, exit_code = do_with_fake_io {
+      Standard::Cli.new(["test/fixture/comment_directive_test/isolated.rb"]).run
+    }
+
+    assert_equal 0, exit_code
+    assert_empty fake_err.string
+    assert_empty fake_out.string
+  end
 end


### PR DESCRIPTION
Version 1.20 upgraded rubocop 1.40.  That version of Rubocop contains an optimization which breaks checking for directives in files that do not have any reference to "rubocop" due to [this change](https://github.com/rubocop/rubocop/commit/f609ddbe0e6700edb58689195b0ff115ab53dd61#diff-b5e024db974dc190ccd9230f20ae35200744480c7bc77b9c7b5e078b04425af4R34).

This did not trigger a fail in any test here because the fixture has a reference to "rubocop" within it. Removing it triggers this scenario.

Fixes #497.