### PR TITLE
Add a new feature to Standard to allow it to run plugins & custom cops

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,12 +492,50 @@ either:
   gem to your build, which will automatically ensure that the comment is
   prepended for every applicable file in your project
 
-## How do I use Standard with RuboCop extensions?
+## How do I use Standard with RuboCop extensions or custom rules?
 
-This is not officially supported by Standard. However, Evil Martians wrote up [a
-regularly updated
+If you want to use Standard in conjunction with RuboCop extensions or custom
+cops, you can specify them in your own [RuboCop configuration
+YAML](https://docs.rubocop.org/rubocop/configuration.html) files and
+`.standard.yml` using the "extend_config:` setting:
+
+```yml
+# .standard.yml
+extend_config:
+  - .betterlint.yml
+```
+
+Which in turn would refer to a RuboCop configuration file:
+
+```yml
+# .betterlint.yml
+require:
+  - rubocop/cop/betterment.rb
+
+AllCops:
+  DisabledByDefault: true
+
+Betterment/UnscopedFind:
+  Enabled: true
+
+  unauthenticated_models:
+    - SystemConfiguration
+```
+
+When Standard runs, it will merge your configuration files with Standard's base
+ruleset. To ensure that this feature does not result in Standard's rules being
+modified, any configuration of rules includued in `rubocop` or
+`rubocop-performance` will be ignored. Most settings under `AllCops:` can be
+configured, unless they'd conflict with a setting used by Standard (like
+`TargetRubyVersion`) or prevent Standard's own rules from running (like
+`StyleGuideCopsOnly`). If you specify multiple YAML files under `extend_config`,
+note that their resulting RuboCop configurations will be merged in order (i.e.
+last-in-wins).
+
+If you find that Standard's `extend_config` feature doesn't meet your needs,
+Evil Martians also maintains [a regularly updated
 guide](https://evilmartians.com/chronicles/rubocoping-with-legacy-bring-your-ruby-code-up-to-standard)
-on how to do so.
+on how to configure RuboCop to load and execute Standard's ruleset.
 
 ## How often is Standard updated?
 

--- a/lib/standard/creates_config_store.rb
+++ b/lib/standard/creates_config_store.rb
@@ -3,6 +3,7 @@ require "rubocop"
 require_relative "creates_config_store/assigns_rubocop_yaml"
 require_relative "creates_config_store/sets_target_ruby_version"
 require_relative "creates_config_store/configures_ignored_paths"
+require_relative "creates_config_store/merges_user_config_extensions"
 
 module Standard
   class CreatesConfigStore
@@ -10,6 +11,7 @@ module Standard
       @assigns_rubocop_yaml = AssignsRubocopYaml.new
       @sets_target_ruby_version = SetsTargetRubyVersion.new
       @configures_ignored_paths = ConfiguresIgnoredPaths.new
+      @merges_user_config_extensions = MergesUserConfigExtensions.new
     end
 
     def call(standard_config)
@@ -17,6 +19,7 @@ module Standard
         options_config = @assigns_rubocop_yaml.call(config_store, standard_config)
         @sets_target_ruby_version.call(options_config, standard_config)
         @configures_ignored_paths.call(options_config, standard_config)
+        @merges_user_config_extensions.call(options_config, standard_config)
       end
     end
   end

--- a/lib/standard/creates_config_store/merges_user_config_extensions.rb
+++ b/lib/standard/creates_config_store/merges_user_config_extensions.rb
@@ -26,21 +26,25 @@ class Standard::CreatesConfigStore
         standard_config[:extend_config].each do |path|
           extension = RuboCop::ConfigLoader.load_file(Standard::FileFinder.new.call(path, Dir.pwd)).to_h
           config["AllCops"].merge!(extension["AllCops"]) if extension.key?("AllCops")
-          config.merge!(extension.except("AllCops"))
+          config.merge!(except(extension, ["AllCops"]))
         end
       end
     end
 
     def merge_standard_and_user_all_cops!(options_config, extended_config)
       options_config["AllCops"].merge!(
-        extended_config["AllCops"].except(*DISALLOWED_ALLCOPS_KEYS)
+        except(extended_config["AllCops"], DISALLOWED_ALLCOPS_KEYS)
       )
     end
 
     def merge_extended_rules_into_standard!(options_config, extended_config)
-      extended_config.except(*options_config.keys).each do |key, value|
+      except(extended_config, options_config.keys).each do |key, value|
         options_config[key] = value
       end
+    end
+
+    def except(hash, keys)
+      hash.reject { |key, _| keys.include?(key) }.to_h
     end
   end
 end

--- a/lib/standard/creates_config_store/merges_user_config_extensions.rb
+++ b/lib/standard/creates_config_store/merges_user_config_extensions.rb
@@ -1,0 +1,46 @@
+require_relative "../file_finder"
+
+class Standard::CreatesConfigStore
+  class MergesUserConfigExtensions
+    DISALLOWED_ALLCOPS_KEYS = [
+      "Include",
+      "Exclude",
+      "StyleGuideCopsOnly",
+      "TargetRubyVersion"
+    ].freeze
+
+    def call(options_config, standard_config)
+      return unless standard_config[:extend_config]&.any?
+
+      extended_config = load_and_merge_extended_rubocop_configs(standard_config)
+      merge_standard_and_user_all_cops!(options_config, extended_config)
+      merge_extended_rules_into_standard!(options_config, extended_config)
+    end
+
+    private
+
+    def load_and_merge_extended_rubocop_configs(standard_config)
+      {
+        "AllCops" => {}
+      }.tap do |config|
+        standard_config[:extend_config].each do |path|
+          extension = RuboCop::ConfigLoader.load_file(Standard::FileFinder.new.call(path, Dir.pwd)).to_h
+          config["AllCops"].merge!(extension["AllCops"]) if extension.key?("AllCops")
+          config.merge!(extension.except("AllCops"))
+        end
+      end
+    end
+
+    def merge_standard_and_user_all_cops!(options_config, extended_config)
+      options_config["AllCops"].merge!(
+        extended_config["AllCops"].except(*DISALLOWED_ALLCOPS_KEYS)
+      )
+    end
+
+    def merge_extended_rules_into_standard!(options_config, extended_config)
+      extended_config.except(*options_config.keys).each do |key, value|
+        options_config[key] = value
+      end
+    end
+  end
+end

--- a/lib/standard/loads_yaml_config.rb
+++ b/lib/standard/loads_yaml_config.rb
@@ -32,7 +32,8 @@ module Standard
         default_ignores: standard_yaml.key?("default_ignores") ? !!standard_yaml["default_ignores"] : true,
         config_root: yaml_path ? Pathname.new(yaml_path).dirname.to_s : nil,
         todo_file: todo_path,
-        todo_ignore_files: (todo_yaml["ignore"] || []).map { |f| (Hash === f) ? f.keys.first : f }
+        todo_ignore_files: Array(todo_yaml["ignore"]).map { |f| (Hash === f) ? f.keys.first : f },
+        extend_config: Array(standard_yaml["extend_config"])
       }
     end
 

--- a/test/fixture/extend_config/all_cops.yml
+++ b/test/fixture/extend_config/all_cops.yml
@@ -1,0 +1,5 @@
+AllCops:
+  TargetRubyVersion: 4.0
+  StyleGuideBaseURL: https://all_cops.yml
+  DisabledByDefault: true
+  StyleGuideCopsOnly: true

--- a/test/fixture/extend_config/bananas.rb
+++ b/test/fixture/extend_config/bananas.rb
@@ -1,0 +1,15 @@
+module RuboCop
+  module Cop
+    module Bananas
+      class BananasOnly < Cop
+        def on_lvasgn(node)
+          name, = *node
+
+          if name != :bananas
+            add_offense(node, message: "Bananas only! No oranges.")
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/fixture/extend_config/betterlint.yml
+++ b/test/fixture/extend_config/betterlint.yml
@@ -1,0 +1,10 @@
+require:
+  - fixture/extend_config/betterment.rb
+
+AllCops:
+  StyleGuideBaseURL: https://betterlint.yml
+
+Betterment/UnscopedFind:
+  Enabled: true
+  unauthenticated_models:
+    - SystemConfiguration

--- a/test/fixture/extend_config/betterment.rb
+++ b/test/fixture/extend_config/betterment.rb
@@ -1,0 +1,8 @@
+module RuboCop
+  module Cop
+    module Betterment
+      class UnscopedFind < Cop
+      end
+    end
+  end
+end

--- a/test/fixture/extend_config/monkey_business.yml
+++ b/test/fixture/extend_config/monkey_business.yml
@@ -1,0 +1,9 @@
+AllCops:
+  TargetRubyVersion: 1.8.6
+
+Betterment/UnscopedFind:
+  Enabled: false
+
+Naming/VariableName:
+  Enabled: false
+  EnforcedStyle: camelCase

--- a/test/fixture/extend_config/project/.bananas.yml
+++ b/test/fixture/extend_config/project/.bananas.yml
@@ -1,0 +1,8 @@
+require:
+  - ../bananas.rb
+
+AllCops:
+  DisabledByDefault: true
+
+Bananas/BananasOnly:
+  Enabled: true

--- a/test/fixture/extend_config/project/.standard.yml
+++ b/test/fixture/extend_config/project/.standard.yml
@@ -1,0 +1,1 @@
+extend_config: .bananas.yml

--- a/test/fixture/extend_config/project/oranges.rb
+++ b/test/fixture/extend_config/project/oranges.rb
@@ -1,0 +1,2 @@
+oranges = "🍊🍊🍊"
+puts oranges

--- a/test/standard/creates_config_store/merges_user_config_extensions_test.rb
+++ b/test/standard/creates_config_store/merges_user_config_extensions_test.rb
@@ -1,0 +1,103 @@
+require_relative "../../test_helper"
+
+class Standard::CreatesConfigStore::MergesUserConfigExtensionsTest < UnitTest
+  def setup
+    @subject = Standard::CreatesConfigStore::MergesUserConfigExtensions.new
+  end
+
+  def test_doesnt_change_config_when_no_extensions_defined
+    options_config = {
+      "AllCops" => {}
+    }
+
+    @subject.call(options_config, {
+      extend_config: []
+    })
+
+    assert_equal({
+      "AllCops" => {}
+    }, options_config)
+  end
+
+  def test_when_one_file_extends
+    options_config = {
+      "AllCops" => {
+        "TargetRubyVersion" => "2.6"
+      }
+    }
+
+    @subject.call(options_config, {
+      extend_config: ["test/fixture/extend_config/all_cops.yml"]
+    })
+
+    assert_equal({
+      "AllCops" => {
+        # Ignored b/c DISALLOWED_ALLCOPS_KEYS
+        "TargetRubyVersion" => "2.6",
+        # Excluded b/c DISALLOWED_ALLCOPS_KEYS
+        # "StyleGuideCopsOnly" => false,
+
+        # Allowed to overwrite
+        "DisabledByDefault" => true,
+        "StyleGuideBaseURL" => "https://all_cops.yml"
+      }
+    }, options_config)
+  end
+
+  def test_when_two_files_extend
+    options_config = {
+      "AllCops" => {}
+    }
+
+    @subject.call(options_config, {
+      extend_config: [
+        "test/fixture/extend_config/all_cops.yml",
+        "test/fixture/extend_config/betterlint.yml"
+      ]
+    })
+
+    assert_equal({
+      "AllCops" => {
+        "DisabledByDefault" => true,
+        # Last-in wins
+        "StyleGuideBaseURL" => "https://betterlint.yml"
+      },
+      "Betterment/UnscopedFind" => {
+        "Enabled" => true,
+        "unauthenticated_models" => ["SystemConfiguration"]
+      }
+    }, options_config)
+  end
+
+  def test_when_three_files_extend_with_monkey_business
+    options_config = {
+      "AllCops" => {},
+      "Naming/VariableName" => {"Enabled" => true}
+    }
+
+    @subject.call(options_config, {
+      extend_config: [
+        "test/fixture/extend_config/all_cops.yml",
+        "test/fixture/extend_config/betterlint.yml",
+        "test/fixture/extend_config/monkey_business.yml"
+      ]
+    })
+
+    assert_equal({
+      "AllCops" => {
+        "DisabledByDefault" => true,
+        "StyleGuideBaseURL" => "https://betterlint.yml"
+      },
+
+      # Last-in wins, shallow merge for nested hashes other than AllCops
+      "Betterment/UnscopedFind" => {
+        "Enabled" => false
+      },
+
+      # Note that Naming/VariableName is not modified here, b/c it's a built-in
+      "Naming/VariableName" => {
+        "Enabled" => true
+      }
+    }, options_config)
+  end
+end

--- a/test/standard/creates_config_store_test.rb
+++ b/test/standard/creates_config_store_test.rb
@@ -6,6 +6,7 @@ class Standard::CreatesConfigStore
       @assigns_rubocop_yaml = gimme_next(AssignsRubocopYaml)
       @sets_target_ruby_version = gimme_next(SetsTargetRubyVersion)
       @configures_ignored_paths = gimme_next(ConfiguresIgnoredPaths)
+      @merges_user_config_extensions = gimme_next(MergesUserConfigExtensions)
 
       @subject = Standard::CreatesConfigStore.new
     end
@@ -19,6 +20,7 @@ class Standard::CreatesConfigStore
 
       verify(@sets_target_ruby_version).call(options_config, standard_config)
       verify(@configures_ignored_paths).call(options_config, standard_config)
+      verify(@merges_user_config_extensions).call(options_config, standard_config)
     end
   end
 end

--- a/test/standard/loads_yaml_config_test.rb
+++ b/test/standard/loads_yaml_config_test.rb
@@ -10,7 +10,8 @@ class Standard::LoadsYamlConfigTest < UnitTest
     default_ignores: true,
     config_root: nil,
     todo_file: nil,
-    todo_ignore_files: []
+    todo_ignore_files: [],
+    extend_config: []
   }.freeze
 
   def setup

--- a/test/standardrb_test.rb
+++ b/test/standardrb_test.rb
@@ -40,6 +40,16 @@ class StandardrbTest < UnitTest
     ]
   end
 
+  def test_extend_config_option
+    stdout, status = run_standardrb("test/fixture/extend_config/project")
+
+    refute status.success?
+    assert_same_lines <<-MSG.gsub(/^ {6}/, ""), stdout
+      #{standard_greeting}
+        oranges.rb:1:1: Bananas/BananasOnly: Bananas only! No oranges.
+    MSG
+  end
+
   private
 
   def run_standardrb(cwd, args = [])


### PR DESCRIPTION
This one has been a long time coming. Right now, if you run Standard but have any cause to run any additional RuboCop rules (whether a gem plugin like [betterlint](https://github.com/Betterment/betterlint) for your Rails app) or a custom cop that's maintained in your own codebase, you've had to either run `standardrb` alongside `rubocop` or load Standard's ruleset into a `rubocop` configuration like [this guide by Evil Martians](https://evilmartians.com/chronicles/rubocoping-with-legacy-bring-your-ruby-code-up-to-standard) explains.

Neither option is great—the former is slow and the latter risks overwriting or modifying Standard's rules—often invisibly—such that code you thought was Standard-compliant was actually being impacted by an arbitrary gem you required.

To remedy this issue, this PR adds a new configuration property for your `.standard.yml` file called `extend_config`. It takes one or more _RuboCop_ YAML file locations which can require files and gems of other cops, configure their rules, and even inherit from yet other RuboCop configurations.

To wit, you could add this to your `.standard.yml` file:

```yml
extend_config:
  - .betterlint.yml
```

And `.betterlint.yml` might look like:

```yml
require:
  - rubocop/cop/betterment.rb

AllCops:
  DisabledByDefault: true

Betterment/UnscopedFind:
  Enabled: true

  unauthenticated_models:
    - SystemConfiguration
```

From then on, any invocation of `standardrb` or `rake standard` will run your code through _both_ Standard's ruleset as well as `Betterment/UnscopedFind`.

At runtime, Standard will merge in all the new rules while excluding any changes to the built-in cops it cares about (which is to say, any cops that ship with either the `rubocop` or `rubocop-performance` gems). It will also allow the majority of top-level configurations on the `AllCops` section to be modified (since they won't affect Standard's core behavior).

Hopefully this makes Standard easier to adopt and to use exclusively for your Ruby linting & formatting needs! 💚

Todo list:

- [x] Make it work in 2.7 lol