### PR TITLE
Allow empty else that have comments

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -1269,6 +1269,7 @@ Style/EmptyCaseCondition:
 
 Style/EmptyElse:
   Enabled: true
+  AllowComments: true
   EnforcedStyle: both
 
 Style/EmptyHeredoc:


### PR DESCRIPTION
This option was added in Rubocop 1.32 https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md#1320-2022-07-21.
It mirrors what Standard already allows for EmptyWhen.