### PR TITLE
Add Arrows to list of standard users

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Here are a few examples of Ruby Standard-compliant teams & projects:
 
 * [Test Double](https://testdouble.com/agency)
 * [Amazon Web Services](https://aws.amazon.com/)
+* [Arrows](https://arrows.to/)
 * [Babylist](https://www.babylist.com/)
 * [Brand New Box](https://brandnewbox.com)
 * [Brave Software](https://github.com/brave-intl/publishers)


### PR DESCRIPTION
We are happy users of `standard` for our Rails app at https://arrows.to