### PR TITLE
Support extending default configuration via extend_configs

### DIFF
--- a/lib/standard/creates_config_store/merges_user_config_extensions.rb
+++ b/lib/standard/creates_config_store/merges_user_config_extensions.rb
@@ -20,15 +20,33 @@ class Standard::CreatesConfigStore
     private
 
     def load_and_merge_extended_rubocop_configs(standard_config)
-      {
-        "AllCops" => {}
-      }.tap do |config|
-        standard_config[:extend_config].each do |path|
-          extension = RuboCop::ConfigLoader.load_file(Standard::FileFinder.new.call(path, Dir.pwd)).to_h
-          config["AllCops"].merge!(extension["AllCops"]) if extension.key?("AllCops")
-          config.merge!(except(extension, ["AllCops"]))
-        end
+      # Blank configuration object to merge extensions into
+      config = RuboCop::Config.new({"AllCops" => {}}, "")
+
+      orig_default_config = RuboCop::ConfigLoader.instance_variable_get(:@default_configuration)
+
+      standard_config[:extend_config].each do |path|
+        # RuboCop plugins often modify the default configuration in-place
+        # (e.g., load custom base configurations)
+        #
+        # So, we provide our blank configuration as a default one,
+        # to make sure all modifications have been applied
+        RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, config)
+
+        path = Standard::FileFinder.new.call(path, Dir.pwd)
+
+        extension = RuboCop::ConfigLoader.load_file(path)
+
+        config = RuboCop::ConfigLoader.merge_with_default(extension, path)
       end
+
+      # Restore default configuration to the original state
+      RuboCop::ConfigLoader.instance_variable_set(:@default_configuration, orig_default_config)
+
+      # The Enabled key is an unused artefact of #merge_with_default
+      config["AllCops"].delete("Enabled")
+
+      config.to_h
     end
 
     def merge_standard_and_user_all_cops!(options_config, extended_config)

--- a/test/standard/creates_config_store/merges_user_config_extensions_test.rb
+++ b/test/standard/creates_config_store/merges_user_config_extensions_test.rb
@@ -89,9 +89,10 @@ class Standard::CreatesConfigStore::MergesUserConfigExtensionsTest < UnitTest
         "StyleGuideBaseURL" => "https://betterlint.yml"
       },
 
-      # Last-in wins, shallow merge for nested hashes other than AllCops
+      # Last-in wins, deep merge for nested hashes
       "Betterment/UnscopedFind" => {
-        "Enabled" => false
+        "Enabled" => false,
+        "unauthenticated_models" => ["SystemConfiguration"]
       },
 
       # Note that Naming/VariableName is not modified here, b/c it's a built-in


### PR DESCRIPTION
Fixes #507

Many RuboCop plugins extend the default RuboCop configuration (`RuboCop::ConfigLoader.default_configuration` singleton) in-place to register and configure their cops. Usually it's done via the `inject!` script (like this one from [rubocop-rspec](https://github.com/rubocop/rubocop-rspec/blob/68252e8311ddc8c83f41c3571f30b5eff6b0b7ac/lib/rubocop/rspec/inject.rb#L8)). 

To support this pattern when using Standard's `extend_configs`, we hijack the default configuration during extension and use it as a target for loaded extensions.