### PR TITLE
What if I told you there were more LSP improvements

### DIFF
--- a/lib/standard/lsp/logger.rb
+++ b/lib/standard/lsp/logger.rb
@@ -1,8 +1,18 @@
 module Standard
   module Lsp
     class Logger
+      def initialize
+        @puts_onces = []
+      end
+
       def puts(message)
         warn("[server] #{message}")
+      end
+
+      def puts_once(message)
+        return if @puts_onces.include?(message)
+        @puts_onces << message
+        puts(message)
       end
     end
   end

--- a/lib/standard/lsp/routes.rb
+++ b/lib/standard/lsp/routes.rb
@@ -130,13 +130,18 @@ module Standard
 
       private
 
+      def uri_to_path(uri)
+        # TODO: make this real
+        uri.sub(%r{^file:///}, "")
+      end
+
       def format_file(file_uri)
         text = @text_cache[file_uri]
         if text.nil?
           @logger.puts "Format request arrived before text synchonized; skipping: `#{file_uri}'"
           []
         else
-          new_text = @standardizer.format(text)
+          new_text = @standardizer.format(uri_to_path(file_uri), text)
           if new_text == text
             []
           else
@@ -153,7 +158,7 @@ module Standard
 
       def diagnostic(file_uri, text)
         @text_cache[file_uri] = text
-        offenses = @standardizer.offenses(text)
+        offenses = @standardizer.offenses(uri_to_path(file_uri), text)
 
         lsp_diagnostics = offenses.map { |o|
           code = o[:cop_name]

--- a/lib/standard/lsp/routes.rb
+++ b/lib/standard/lsp/routes.rb
@@ -131,8 +131,7 @@ module Standard
       private
 
       def uri_to_path(uri)
-        # TODO: make this real
-        uri.sub(%r{^file:///}, "")
+        uri.sub(%r{^file://}, "")
       end
 
       def format_file(file_uri)

--- a/lib/standard/lsp/server.rb
+++ b/lib/standard/lsp/server.rb
@@ -9,15 +9,11 @@ module Standard
     SEV = Proto::Constant::DiagnosticSeverity
 
     class Server
-      def self.start(standardizer)
-        new(standardizer).start
-      end
-
-      def initialize(standardizer)
-        @standardizer = standardizer
+      def initialize(config)
         @writer = Proto::Transport::Io::Writer.new($stdout)
         @reader = Proto::Transport::Io::Reader.new($stdin)
         @logger = Logger.new
+        @standardizer = Standard::Lsp::Standardizer.new(config, @logger)
         @routes = Routes.new(@writer, @logger, @standardizer)
       end
 

--- a/lib/standard/lsp/standardizer.rb
+++ b/lib/standard/lsp/standardizer.rb
@@ -1,49 +1,51 @@
 require_relative "../runners/rubocop"
-require "tempfile"
 
 module Standard
   module Lsp
     class Standardizer
       def initialize(config)
-        @template_options = config
-        @runner = Standard::Runners::Rubocop.new
+        @config = config
+        @rubocop_runner = Standard::Runners::Rubocop.new
       end
 
-      def format(text)
-        run_standard(text, format: true)
+      # This abuses the --stdin option of rubocop and reads the formatted text
+      # from the options[:stdin] that rubocop mutates. This depends on
+      # parallel: false as well as the fact that rubocop doesn't otherwise dup
+      # or reassign that options object. Risky business!
+      #
+      # Reassigning options[:stdin] is done here:
+      #   https://github.com/rubocop/rubocop/blob/master/lib/rubocop/cop/team.rb#L131
+      # Printing options[:stdin]
+      #   https://github.com/rubocop/rubocop/blob/master/lib/rubocop/cli/command/execute_runner.rb#L95
+      # Setting `parallel: true` would break this here:
+      #   https://github.com/rubocop/rubocop/blob/master/lib/rubocop/runner.rb#L72
+      def format(path, text)
+        ad_hoc_config = fork_config(path, text, format: true)
+        capture_rubocop_stdout(ad_hoc_config)
+        ad_hoc_config.rubocop_options[:stdin]
       end
 
-      def offenses(text)
-        results = run_standard(text, format: false)
+      def offenses(path, text)
+        results = capture_rubocop_stdout(fork_config(path, text, format: false))
         JSON.parse(results, symbolize_names: true).dig(:files, 0, :offenses)
       end
 
       private
 
-      BASENAME = ["source", ".rb"].freeze
-      def run_standard(text, format:)
-        Tempfile.open(BASENAME) do |temp|
-          temp.write(text)
-          temp.flush
-          stdout = capture_rubocop_stdout(make_config(temp.path, format))
-          format ? File.read(temp.path) : stdout
-        end
-      end
-
-      def make_config(file, format)
-        # Can't make frozen versions of this hash because RuboCop mutates it
+      # Can't make frozen versions of this hash because RuboCop mutates it
+      def fork_config(path, text, format:)
         o = if format
-          {autocorrect: true, formatters: [["Standard::Formatter", nil]], parallel: true, todo_file: nil, todo_ignore_files: [], safe_autocorrect: true}
+          {stdin: text, autocorrect: true, formatters: [["Standard::Formatter", nil]], parallel: false, todo_file: nil, todo_ignore_files: [], safe_autocorrect: true}
         else
-          {autocorrect: false, formatters: [["json"]], parallel: true, todo_file: nil, todo_ignore_files: [], format: "json"}
+          {stdin: text, autocorrect: false, formatters: [["json"]], parallel: false, todo_file: nil, todo_ignore_files: [], format: "json"}
         end
-        Standard::Config.new(@template_options.runner, [file], o, @template_options.rubocop_config_store)
+        Standard::Config.new(@config.runner, [path], o, @config.rubocop_config_store)
       end
 
       def capture_rubocop_stdout(config)
         redir = StringIO.new
         $stdout = redir
-        @runner.call(config)
+        @rubocop_runner.call(config)
         redir.string
       ensure
         $stdout = STDOUT

--- a/lib/standard/lsp/standardizer.rb
+++ b/lib/standard/lsp/standardizer.rb
@@ -32,7 +32,7 @@ module Standard
           symbolize_names: true
         )
         if results[:files].empty?
-          @logger.puts "Ignoring file, per configuration: #{path}"
+          @logger.puts_once "Ignoring file, per configuration: #{path}"
           []
         else
           results.dig(:files, 0, :offenses)

--- a/lib/standard/runners/lsp.rb
+++ b/lib/standard/runners/lsp.rb
@@ -4,8 +4,7 @@ module Standard
   module Runners
     class Lsp
       def call(config)
-        standardizer = Standard::Lsp::Standardizer.new(config)
-        Standard::Lsp::Server.start(standardizer)
+        Standard::Lsp::Server.new(config).start
       end
     end
   end

--- a/test/standard/runners/lsp_test.rb
+++ b/test/standard/runners/lsp_test.rb
@@ -485,7 +485,7 @@ class Standard::Runners::LspTest < UnitTest
       },
       format_result
     )
-    assert_match "[server] Ignoring file, per configuration: #{Dir.pwd}/tmp/zzz.rb", err.string
+    assert_equal "[server] Ignoring file, per configuration: #{Dir.pwd}/tmp/zzz.rb", err.string.chomp
   end
 
   private

--- a/test/standard/runners/lsp_test.rb
+++ b/test/standard/runners/lsp_test.rb
@@ -117,7 +117,7 @@ class Standard::Runners::LspTest < UnitTest
         params: {
           textDocument: {
             languageId: "ruby",
-            text: "def hi\n  [1, 2,\n   3  ]\nend\n",
+            text: "puts 'hi'",
             uri: "file:///path/to/file.rb",
             version: 0
           }
@@ -127,7 +127,7 @@ class Standard::Runners::LspTest < UnitTest
         method: "textDocument/didChange",
         jsonrpc: "2.0",
         params: {
-          contentChanges: [{text: "def goodbye\n  [3, 2,\n   1  ]\n\nend\n"}],
+          contentChanges: [{text: "puts 'bye'"}],
           textDocument: {
             uri: "file:///path/to/file.rb",
             version: 10
@@ -151,10 +151,10 @@ class Standard::Runners::LspTest < UnitTest
       {
         id: 20,
         result: [
-          {newText: "def goodbye\n  [3, 2,\n    1]\nend\n",
+          {newText: "puts \"bye\"\n",
            range: {
              start: {line: 0, character: 0},
-             end: {line: 6, character: 0}
+             end: {line: 1, character: 0}
            }}
         ],
         jsonrpc: "2.0"

--- a/test/standard/runners/lsp_test.rb
+++ b/test/standard/runners/lsp_test.rb
@@ -370,6 +370,124 @@ class Standard::Runners::LspTest < UnitTest
     }, msgs.last)
   end
 
+  def test_did_open_on_ignored_path
+    msgs, err = run_server_on_requests({
+      method: "textDocument/didOpen",
+      jsonrpc: "2.0",
+      params: {
+        textDocument: {
+          languageId: "ruby",
+          text: "puts 'neat'",
+          # Depends on this project's .standard.yml ignoring `tmp/**/*`
+          uri: "file://#{Dir.pwd}/tmp/foo/bar.rb",
+          version: 0
+        }
+      }
+    })
+
+    assert_equal 1, msgs.count
+    assert_equal({
+      method: "textDocument/publishDiagnostics",
+      params: {
+        diagnostics: [],
+        uri: "file://#{Dir.pwd}/tmp/foo/bar.rb"
+      },
+      jsonrpc: "2.0"
+    }, msgs.first)
+    assert_equal "[server] Ignoring file, per configuration: #{Dir.pwd}/tmp/foo/bar.rb", err.string.chomp
+  end
+
+  def test_formatting_via_execute_command_on_ignored_path
+    msgs, err = run_server_on_requests(
+      {
+        method: "textDocument/didOpen",
+        jsonrpc: "2.0",
+        params: {
+          textDocument: {
+            languageId: "ruby",
+            text: "puts 'hi'",
+            # Depends on this project's .standard.yml ignoring `tmp/**/*`
+            uri: "file://#{Dir.pwd}/tmp/baz.rb",
+            version: 0
+          }
+        }
+      },
+      {
+        method: "workspace/executeCommand",
+        id: 99,
+        jsonrpc: "2.0",
+        params: {
+          command: "standardRuby.formatAutoFixes",
+          arguments: [{uri: "file://#{Dir.pwd}/tmp/baz.rb"}]
+        }
+      }
+    )
+
+    assert_equal({
+      id: 99,
+      method: "workspace/applyEdit",
+      params: {
+        label: "Format with Standard Ruby auto-fixes",
+        edit: {
+          changes: {
+            "file://#{Dir.pwd}/tmp/baz.rb": []
+          }
+        }
+      },
+      jsonrpc: "2.0"
+    }, msgs.last)
+    assert_equal "[server] Ignoring file, per configuration: #{Dir.pwd}/tmp/baz.rb", err.string.chomp
+  end
+
+  def test_formatting_via_formatting_path_on_ignored_path
+    msgs, err = run_server_on_requests(
+      {
+        method: "textDocument/didOpen",
+        jsonrpc: "2.0",
+        params: {
+          textDocument: {
+            languageId: "ruby",
+            text: "puts 'hi'",
+            # Depends on this project's .standard.yml ignoring `tmp/**/*`
+            uri: "file://#{Dir.pwd}/tmp/zzz.rb",
+            version: 0
+          }
+        }
+      },
+      {
+        method: "textDocument/didChange",
+        jsonrpc: "2.0",
+        params: {
+          contentChanges: [{text: "puts 'bye'"}],
+          textDocument: {
+            uri: "file://#{Dir.pwd}/tmp/zzz.rb",
+            version: 10
+          }
+        }
+      },
+      {
+        method: "textDocument/formatting",
+        id: 20,
+        jsonrpc: "2.0",
+        params: {
+          options: {insertSpaces: true, tabSize: 2},
+          textDocument: {uri: "file://#{Dir.pwd}/tmp/zzz.rb"}
+        }
+      }
+    )
+
+    format_result = msgs.last
+    assert_equal(
+      {
+        id: 20,
+        result: [],
+        jsonrpc: "2.0"
+      },
+      format_result
+    )
+    assert_match "[server] Ignoring file, per configuration: #{Dir.pwd}/tmp/zzz.rb", err.string
+  end
+
   private
 
   def run_server_on_requests(*requests)


### PR DESCRIPTION
Using stdin instead of tempfiles is a significant speed improvement.

Running before this commit: 0.129s - 0.141s
Running lsp_test.rb after this commit: 0.075s - 0.085s

- [x] use stdin instead of temp files
- [x] send a cwd-relative path name correctly to rubocop
- [x] figure out how to ignore paths when .standard.yml would ignore them (possibly using `TargetFiles#find` and passing the basename of the file's dir to see if it comes back? Would result in false positive for unsaved files…)