### PR TITLE
fix(lsp): Request document sync on open/close

### DIFF
--- a/lib/standard/lsp/routes.rb
+++ b/lib/standard/lsp/routes.rb
@@ -30,7 +30,8 @@ module Standard
             diagnostic_provider: true,
             execute_command_provider: true,
             text_document_sync: Proto::Interface::TextDocumentSyncOptions.new(
-              change: Proto::Constant::TextDocumentSyncKind::FULL
+              change: Proto::Constant::TextDocumentSyncKind::FULL,
+              open_close: true
             )
           )
         ))

--- a/test/standard/runners/lsp_test.rb
+++ b/test/standard/runners/lsp_test.rb
@@ -16,7 +16,7 @@ class Standard::Runners::LspTest < UnitTest
     assert_equal msgs.first, {
       id: 2,
       result: {capabilities: {
-        textDocumentSync: {change: 1},
+        textDocumentSync: {openClose: true, change: 1},
         documentFormattingProvider: true,
         diagnosticProvider: true,
         executeCommandProvider: true


### PR DESCRIPTION
Without sending `open_close: true` to the client, it may not issue an `textDocument/didOpen` event with document text to allow the diagnostics and text cache to be initialized after opening, but prior to editing, the document.  Format requests also emit "Format request arrived before text synchronized" in this state.  The didClose event probably also doesn't arrive to see cache entries removed.

Observed in neovim 0.8.3 using internal client, while vim with prabirshrestha/vim-lsp sends the event regardless (but does not currently issue didClose).