### PR TITLE
Return an ExecuteCommandOptions struct in place of a boolean

### DIFF
--- a/lib/standard/lsp/routes.rb
+++ b/lib/standard/lsp/routes.rb
@@ -28,7 +28,9 @@ module Standard
           capabilities: Proto::Interface::ServerCapabilities.new(
             document_formatting_provider: true,
             diagnostic_provider: true,
-            execute_command_provider: true,
+            execute_command_provider: Proto::Interface::ExecuteCommandOptions.new(
+              commands: ["standardRuby.formatAutoFixes"]
+            ),
             text_document_sync: Proto::Interface::TextDocumentSyncOptions.new(
               change: Proto::Constant::TextDocumentSyncKind::FULL,
               open_close: true

--- a/test/standard/runners/lsp_test.rb
+++ b/test/standard/runners/lsp_test.rb
@@ -19,7 +19,7 @@ class Standard::Runners::LspTest < UnitTest
         textDocumentSync: {openClose: true, change: 1},
         documentFormattingProvider: true,
         diagnosticProvider: true,
-        executeCommandProvider: true
+        executeCommandProvider: {commands: ["standardRuby.formatAutoFixes"]}
       }},
       jsonrpc: "2.0"
     }


### PR DESCRIPTION
Return an ExecuteCommandOptions struct for `execute_command_options`, rather than a boolean

Fixes #542

This at least seems to allow Helix to register the LSP server and I get diagnostics through from StandardRB, whereas previously nothing at all was working. Formatting doesn't seem to work but that may well be a configuration issue at my end, I'm new to Helix.